### PR TITLE
Cleanup chat when there is no reply to prevent from flood

### DIFF
--- a/src/Watcher/Bot/Parse.hs
+++ b/src/Watcher/Bot/Parse.hs
@@ -88,8 +88,11 @@ handleBan settings Update{..}
       case messageSentFrom settings msg of
         OwnerGroup -> Nothing
         DirectMessage _userId -> Nothing
-        PublicGroup groupId userId -> Just
-          . BanAction groupId userId (messageMessageId msg) =<< messageReplyToMessage msg
+        PublicGroup groupId userId -> maybe
+          -- prevent flooding chat
+          (Just $! DeleteMessage groupId $ messageMessageId msg)
+          (Just . BanAction groupId userId (messageMessageId msg))
+          (messageReplyToMessage msg)
         PrivateGroup groupId _userId ->
           Just $ SendContactAndQuit groupId $ messageMessageId msg
         Channel groupId -> Just $ SendContactAndQuit groupId $ messageMessageId msg


### PR DESCRIPTION
`/spam` without reply is tempting users to press it over and over again. Some users could not help themeselves but click on it which leads to flood. This PR is intended to prevent such situation from happening.