### PR TITLE
Store chat titles, don't drop optional values

### DIFF
--- a/config/common/map.dhall
+++ b/config/common/map.dhall
@@ -1,0 +1,28 @@
+-- Source: https://raw.githubusercontent.com/dhall-lang/Prelude/35deff0d41f2bf86c42089c6ca16665537f54d75/List/map
+{-
+Transform a list by applying a function to each element
+
+Examples:
+
+```
+./map Natural Bool Natural/even [ 2, 3, 5 ]
+= [ True, False, False ]
+
+./map Natural Bool Natural/even ([] : List Natural)
+= [] : List Bool
+```
+-}
+    let map
+        : ∀(a : Type) → ∀(b : Type) → (a → b) → List a → List b
+        =   λ(a : Type)
+          → λ(b : Type)
+          → λ(f : a → b)
+          → λ(xs : List a)
+          → List/build
+            b
+            (   λ(list : Type)
+              → λ(cons : b → list → list)
+              → List/fold a xs list (λ(x : a) → cons (f x))
+            )
+
+in  map

--- a/config/migrations/01-optional-chat-titles.dhall
+++ b/config/migrations/01-optional-chat-titles.dhall
@@ -1,0 +1,143 @@
+let Prelude/map = ./common/map.dhall
+
+let IntTextMap = { mapKey : Integer, mapValue : Text }
+
+let PrevMenuId =
+    < MenuRoot
+    | ConsensusRoot
+    | SpamCmdRoot
+    | QuarantineRoot
+    | Done
+    | Multi : Integer
+    | Consensus : Integer
+    | SpamCmd : < SCPoll | SCAdminsCall >
+    | Quarantine : Integer
+    | BotIsAdmin
+    >
+
+let PrevMenuSettings =
+      < MultipleGroupsRoot :
+          { multipleGroupsMenu : List IntTextMap }
+      | MultipleGroupsSelected :
+          { multipleGroupsSelectedChat : Integer
+          , multipleGroupsSelectedSubMenu : PrevMenuId
+          , multipleGroupsSelectedMenu : List IntTextMap
+          }
+      | SingleRoot :
+          { singleGroupChat : Integer
+          , singleGroupSubMenu : PrevMenuId
+          }
+      >
+
+let PrevSetupState =
+    < UserSetupNone
+    | UserSetupInProgress :
+        { userSetupMenu : PrevMenuSettings
+        , userSetupMessageId : Optional Integer
+        }
+    >
+
+let PrevUserSetupState =
+      { userSetupState : PrevSetupState
+      , userContactState : < UserContactNone | UserContactInProgress >
+      , userCurrentState : Optional < UserCurrentSetup | UserCurrentContact >
+      }
+
+
+let PrevUsers = { mapKey : Integer, mapValue : PrevUserSetupState }
+
+-- New one
+
+let IntSomeTextMap = { mapKey : Integer, mapValue : Optional Text }
+
+let MenuSettings =
+      < MultipleGroupsRoot :
+          { multipleGroupsMenu : List IntSomeTextMap }
+      | MultipleGroupsSelected :
+          { multipleGroupsSelectedChat : Integer
+          , multipleGroupsSelectedSubMenu : PrevMenuId
+          , multipleGroupsSelectedMenu : List IntSomeTextMap
+          }
+      | SingleRoot :
+          { singleGroupChat : Integer
+          , singleGroupSubMenu : PrevMenuId
+          }
+      >
+
+let SetupState =
+    < UserSetupNone
+    | UserSetupInProgress :
+        { userSetupMenu : MenuSettings
+        , userSetupMessageId : Optional Integer
+        }
+    >
+
+let UserSetupState =
+      { userSetupState : SetupState
+      , userContactState : < UserContactNone | UserContactInProgress >
+      , userCurrentState : Optional < UserCurrentSetup | UserCurrentContact >
+      }
+
+let Users = { mapKey : Integer, mapValue : UserSetupState }
+
+-- migrate :)
+
+let addSome
+  = λ(old: IntTextMap)
+  → { mapKey = old.mapKey
+    , mapValue = Some old.mapValue
+    }
+let migrateMenuSettings
+  = λ(oldMenuSettings : PrevMenuSettings)
+  → merge {
+    MultipleGroupsRoot
+      = λ(v: { multipleGroupsMenu : List IntTextMap})
+      → MenuSettings.MultipleGroupsRoot { multipleGroupsMenu = Prelude/map IntTextMap IntSomeTextMap addSome v.multipleGroupsMenu },
+    MultipleGroupsSelected
+      = λ(v: { multipleGroupsSelectedChat : Integer
+             , multipleGroupsSelectedSubMenu : PrevMenuId
+             , multipleGroupsSelectedMenu : List IntTextMap
+             })
+      → MenuSettings.MultipleGroupsSelected { multipleGroupsSelectedChat = v.multipleGroupsSelectedChat
+        , multipleGroupsSelectedSubMenu = v.multipleGroupsSelectedSubMenu
+        , multipleGroupsSelectedMenu = Prelude/map IntTextMap IntSomeTextMap addSome v.multipleGroupsSelectedMenu
+        },
+    SingleRoot
+      = λ(v: { singleGroupChat : Integer
+             , singleGroupSubMenu : PrevMenuId
+             })
+      → MenuSettings.SingleRoot v
+  } oldMenuSettings
+
+let migrateSetup
+  = λ(oldSetup : PrevSetupState)
+  → merge {
+  UserSetupNone = SetupState.UserSetupNone,
+  UserSetupInProgress
+    = λ(v: { userSetupMenu : PrevMenuSettings
+           , userSetupMessageId : Optional Integer
+           })
+    → SetupState.UserSetupInProgress
+        { userSetupMenu = migrateMenuSettings v.userSetupMenu
+        , userSetupMessageId = v.userSetupMessageId
+        }
+  } oldSetup
+
+let migrateUserSetup
+  = λ(old : PrevUserSetupState)
+  → old // { userSetupState = migrateSetup old.userSetupState }
+
+let migrateUsers
+  = λ(oldUser : PrevUsers)
+  → { mapKey = oldUser.mapKey
+    , mapValue = migrateUserSetup oldUser.mapValue
+    }
+
+in { migrateUsers = Prelude/map PrevUsers Users migrateUsers }
+
+-- Example:
+--
+-- let users = ./cache/2024-12-02/users/1733163529.dhall
+-- in (./config/migrations/01-optional-chat-titles.dhall).migrateUsers users
+--
+-- OK!

--- a/src/Watcher/Bot/State/User.hs
+++ b/src/Watcher/Bot/State/User.hs
@@ -2,7 +2,6 @@ module Watcher.Bot.State.User where
 
 import Data.HashSet (HashSet)
 import Data.Map.Strict (Map)
-import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import Dhall (FromDhall (..), ToDhall (..))
 import GHC.Generics (Generic)
@@ -81,11 +80,11 @@ setSetupMessageUserState st messageId = case userSetupState st of
     in st { userSetupState = newSetup }
 
 data MenuState
-  = MultipleGroupsRoot { multipleGroupsMenu :: Map ChatId Text }
+  = MultipleGroupsRoot { multipleGroupsMenu :: Map ChatId (Maybe Text) }
   | MultipleGroupsSelected
       { multipleGroupsSelectedChat :: ChatId
       , multipleGroupsSelectedSubMenu :: MenuId
-      , multipleGroupsSelectedMenu :: Map ChatId Text
+      , multipleGroupsSelectedMenu :: Map ChatId (Maybe Text)
       }
   | SingleRoot
       { singleGroupChat :: ChatId
@@ -115,13 +114,8 @@ switchMenu ms currentMenuId chatId = case ms of
     , singleGroupSubMenu = selectNextMenu currentMenuId
     }
 
-chatSetToMap :: HashSet (ChatId, Maybe Text) -> Map ChatId Text
-chatSetToMap = Map.fromList . catMaybes . fmap transform . HS.toList
-  where
-    transform (chatId, Just title) = Just (chatId, title)
-    transform _ = Nothing
+chatSetToMap :: HashSet (ChatId, Maybe Text) -> Map ChatId (Maybe Text)
+chatSetToMap = Map.fromList . HS.toList
 
-chatMapToSet :: Map ChatId Text -> HashSet (ChatId, Maybe Text)
-chatMapToSet = HS.fromList . fmap transform . Map.toList
-  where
-    transform (chatId, title) = (chatId, Just title)
+chatMapToSet :: Map ChatId (Maybe Text) -> HashSet (ChatId, Maybe Text)
+chatMapToSet = HS.fromList . Map.toList


### PR DESCRIPTION
Users that are admins in more than one chat struggle to use bot since lack of chat title and current code are not making possible to store the evidence in cache.

This PR is intended to fix it. Since it changes the shape of the cache, migration has been provided separately. 
Right now bot owner must apply migration manually. In the future, it must be automated via migration worker. Worker itself is out-of-scope of this PR.