### PR TITLE
Don't enforce callback context in root menus

### DIFF
--- a/src/Watcher/Bot/Reply.hs
+++ b/src/Watcher/Bot/Reply.hs
@@ -135,7 +135,7 @@ replyMenu model menuState messageId chatId  _userId = case menuState of
 
 replySingleGroupMenu :: BotState -> ChatId -> MessageId -> MenuId -> BotM ()
 replySingleGroupMenu model chatId messageId = \case
-  MenuRoot -> replySingleGroupRoot model True True (Just chatId) messageId
+  MenuRoot -> replySingleGroupRoot model True False (Just chatId) messageId
   ConsensusRoot -> replyConsensusRoot model messageId
   SpamCmdRoot -> replySpamCmdRoot model messageId
   QuarantineRoot -> replyQuarantineRoot model messageId
@@ -144,7 +144,7 @@ replySingleGroupMenu model chatId messageId = \case
   Consensus _consensus -> replyConsensusRoot model messageId
   SpamCmd _cmd -> replySpamCmdRoot model messageId
   Quarantine _messagesInQuarantine -> replyQuarantineRoot model messageId  
-  BotIsAdmin -> replySingleGroupRoot model True True (Just chatId) messageId
+  BotIsAdmin -> replySingleGroupRoot model True False (Just chatId) messageId
 
 replySingleGroupRoot
   :: HasCallStack
@@ -188,7 +188,7 @@ replyManyGroupsMenu model messageId adminGroups = do
       editMsg = (toEditMessage "Choose group to set up") -- FIXME: configurable
         { editMessageReplyMarkup = Just $ SomeInlineKeyboardMarkup setupKeyboard
         }
-  setupReply model True messageId editMsg
+  setupReply model False messageId editMsg
 
 replyConsensusRoot
   :: HasCallStack => BotState -> MessageId -> BotM ()


### PR DESCRIPTION
Callbacks shouldn't be enforced in root menu.