### PR TITLE
Distinguish callbacks from replies

### DIFF
--- a/src/Watcher/Bot/Handle/Debug.hs
+++ b/src/Watcher/Bot/Handle/Debug.hs
@@ -53,7 +53,7 @@ debugSetup model@BotState{..} Message{..} = do
     alterCache groups chatId go
     writeCache admins userId' $! HS.singleton group
   when readyOrNot $ forM_ mUserId $ \userId' -> setSingleRoot model userId' (fst group)
-  replySingleGroupRoot model readyOrNot False (Just chatId) messageMessageId
+  replySingleGroupRoot model readyOrNot (Just chatId) (ReplySetup messageMessageId)
 
 debugSpam :: BotState -> Message -> BotM ()
 debugSpam model@BotState{..} msg = do

--- a/src/Watcher/Bot/Handle/Setup.hs
+++ b/src/Watcher/Bot/Handle/Setup.hs
@@ -76,13 +76,13 @@ handleNavigate model@BotState{..} userChatId messageId menuId = do
                 { eventUserId = Just userId }
           sendEvent model evt
           completeGroupSetup model chatId userId
-          replyDone model messageId
+          replyDone model (CallbackSetup messageId)
 
         when (setupMenu menuId) $ groupSetup model chatId userId menuId
         when (menuId == BotIsAdmin) $ refreshChatAdmins model chatId
 
         writeCache users userId newerUserState
-        replyMenu model newMenuState messageId chatId userId
+        replyMenu model newMenuState (CallbackSetup messageId) chatId userId
 
 refreshChatAdmins :: BotState -> ChatId -> BotM ()
 refreshChatAdmins model@BotState{..} chatId = do
@@ -122,7 +122,7 @@ setupMultipleGroups
   :: BotState -> UserId -> MessageId -> HashSet (ChatId, Maybe Text) -> BotM ()
 setupMultipleGroups model userId messageId userGroups = do
   setMultipleRoot model userId userGroups
-  replyManyGroupsMenu model messageId userGroups
+  replyManyGroupsMenu model (ReplySetup messageId) userGroups
 
 setMultipleRoot :: BotState -> UserId -> HashSet (ChatId, Maybe Text) -> BotM ()
 setMultipleRoot BotState{..} userId userGroups = alterCache users userId go
@@ -147,7 +147,7 @@ setupSingleGroup model userId messageId group = do
   readyOrNot <- initGroupSetupMaybe model userId group
   when readyOrNot $ setSingleRoot model userId (fst group)
   
-  replySingleGroupRoot model readyOrNot False Nothing messageId 
+  replySingleGroupRoot model readyOrNot Nothing (ReplySetup messageId)
 
 setSingleRoot :: BotState -> UserId -> ChatId -> BotM ()
 setSingleRoot BotState{..} userId chatId = alterCache users userId go

--- a/src/Watcher/Bot/Types/MessageFrom.hs
+++ b/src/Watcher/Bot/Types/MessageFrom.hs
@@ -34,3 +34,13 @@ messageSentFrom botSettings Message{..} =
            (True, True) -> withUser (PublicGroup cid)
            (True, False) -> withUser (PrivateGroup cid)
            (False, _) -> withUser DirectMessage
+
+data SetupMessageId
+  = CallbackSetup MessageId
+  | ReplySetup MessageId
+  deriving (Eq, Show)
+
+setupToMessageId :: SetupMessageId -> MessageId
+setupToMessageId = \case
+  CallbackSetup msgId -> msgId
+  ReplySetup msgId -> msgId


### PR DESCRIPTION
Replace boolean blindness with context provided by data constructors. All navigate-like messages are coming from callbacks. All setup checks are coming from replies.