### PR TITLE
Send `MenuId` instead of `ChatId`

### DIFF
--- a/src/Watcher/Bot/Reply.hs
+++ b/src/Watcher/Bot/Reply.hs
@@ -181,7 +181,7 @@ replyManyGroupsMenu model messageId adminGroups = do
   let makeButton (chatId, mchatTitle) =
         [ actionButton 
             (fromMaybe ("Untitled chat: " <> s2t chatId) mchatTitle)
-            chatId
+            (Multi chatId)
         ]
       setupKeyboard = InlineKeyboardMarkup
         { inlineKeyboardMarkupInlineKeyboard = makeButton <$> HS.toList adminGroups


### PR DESCRIPTION
In callback parser we're trying to obtain `MenuId` but sending `ChatId`.