### PR TITLE
Replace chat title in `chatAdmins` if value is present

### DIFF
--- a/src/Watcher/Bot/Handle/Setup.hs
+++ b/src/Watcher/Bot/Handle/Setup.hs
@@ -112,9 +112,10 @@ refreshChatAdmins model@BotState{..} chatId = do
 
         forM_ newChatAdmins $ \adminId -> do
           let go Nothing = Just $! HS.singleton (chatId, Nothing)
-              go (Just set) = Just $! if Map.member chatId (chatSetToMap set)
-                then HS.insert (chatId, mChatTitle) set
-                else set
+              go (Just set) = Just $! case Map.lookup chatId (chatSetToMap set) of
+                Just (Just _title) -> set
+                -- otherwise, override value in the set
+                _ -> HS.insert (chatId, mChatTitle) set
           alterCache admins adminId go
   pure ()
 


### PR DESCRIPTION
Right now (after #8, #9, #10, #11, #12, #13 and #14) there is a weird state where that same chat is present twice (with and without title).

This MR is intended to sort this mess out by overriding set value if chat title is present and get rid of duplicate. Bonus point: if group is not present in chat, it'd be added!