### PR TITLE
Add setting that prevents sending self-destroyable messages

### DIFF
--- a/config/default.dhall
+++ b/config/default.dhall
@@ -59,6 +59,7 @@ in
     { usersForConsensus = +3
     , spamCommandAction = SpamCommandAction.SCPoll
     , messagesInQuarantine = +5
+    , selfDestroyEnabled = True
     }
 , scores =
     { scoreUserHasNoUsername = 200

--- a/config/migrations/03-switch-self-destroy.dhall
+++ b/config/migrations/03-switch-self-destroy.dhall
@@ -1,0 +1,320 @@
+-- * common
+
+let Prelude/map = ../common/map.dhall
+
+let UTCTime = { date : Date, time : Time, timeZone : TimeZone }
+
+let IntTextMap = { mapKey : Integer, mapValue : Optional Text }
+
+-- * previous
+
+-- ** groups
+
+let PrevPoll =
+      { mapKey : Integer
+      , mapValue :
+          { pollMessageId : Integer
+          , pollSpamMessageId : Integer
+          , pollVoters : List Integer
+          , pollSpamer :
+                { userInfoId : Integer
+                , userInfoFirstName : Text
+                , userInfoLastName : Optional Text
+                , userInfoLink : Text
+                }
+          }
+      }
+
+let PrevChatSetupState =
+      < SetupCompleted :
+          { setupCompletedAt : UTCTime
+          , setupCompletedByAdmin : Integer
+          }
+      | SetupInProgress :
+          { setupModifiedAt : UTCTime
+          , setupModifiedByAdmin : Integer
+          }
+      | SetupNone
+      >
+
+let PrevQuarantine =
+      { mapKey : Integer
+      , mapValue :
+          { _1 : Optional
+              { chatInfoBackgroundCustomEmojiId : Optional Text
+              , chatInfoBio : Optional Text
+              , chatInfoEmojiStatusCustomEmojiId : Optional Text
+              , chatInfoId : Integer
+              , chatInfoName : Text
+              , chatInfoTitle : Optional Text
+              }
+          , _2 : List Bytes
+          }
+      }
+
+let PrevAdminCall =
+      { mapKey : Integer
+      , mapValue :
+          { _1 :
+              { userInfoId : Integer
+              , userInfoFirstName : Text
+              , userInfoLastName : Optional Text
+              , userInfoLink : Text
+              }
+          , _2 :
+              { messageInfoId : Integer
+              , messageInfoThreadId : Optional Integer
+              , messageInfoText : Optional Text
+              , messageInfoFrom :
+                  Optional
+                    { userInfoId : Integer
+                    , userInfoFirstName : Text
+                    , userInfoLastName : Optional Text
+                    , userInfoLink : Text
+                    }
+              , messageInfoChat :
+                  { chatInfoId : Integer
+                  , chatInfoName : Text
+                  , chatInfoTitle : Optional Text
+                  , chatInfoBio : Optional Text
+                  , chatInfoEmojiStatusCustomEmojiId : Optional Text
+                  , chatInfoBackgroundCustomEmojiId : Optional Text
+                  }
+              }
+          }
+      }
+
+let PrevChatSettings =
+      { messagesInQuarantine : Integer
+      , spamCommandAction : < SCAdminsCall | SCPoll >
+      , usersForConsensus : Integer
+      }
+
+let PrevChatState =
+      { activePolls : List PrevPoll
+      , adminCalls : List PrevAdminCall
+      , allowlist : List Integer
+      , botIsAdmin : Bool
+      , chatAdmins : List Integer
+      , chatAdminsCheckedAt : Optional Date
+      , chatSettings : PrevChatSettings
+      , chatSetup : PrevChatSetupState
+      , quarantine : List PrevQuarantine
+      }
+
+let PrevChats = { mapKey : Integer, mapValue : PrevChatState }
+
+-- ** Users
+
+let PrevMenuId =
+    < MenuRoot
+    | ConsensusRoot
+    | SpamCmdRoot
+    | QuarantineRoot
+    | Done
+    | Multi : Integer
+    | Consensus : Integer
+    | SpamCmd : < SCPoll | SCAdminsCall >
+    | Quarantine : Integer
+    | BotIsAdmin
+    >
+
+
+let PrevMenuSettings =
+      < MultipleGroupsRoot :
+          { multipleGroupsMenu : List IntTextMap }
+      | MultipleGroupsSelected :
+          { multipleGroupsSelectedChat : Integer
+          , multipleGroupsSelectedSubMenu : PrevMenuId
+          , multipleGroupsSelectedMenu : List IntTextMap
+          }
+      | SingleRoot :
+          { singleGroupChat : Integer
+          , singleGroupSubMenu : PrevMenuId
+          }
+      >
+
+let PrevSetupState =
+    < UserSetupNone
+    | UserSetupInProgress :
+        { userSetupMenu : PrevMenuSettings
+        , userSetupMessageId : Optional Integer
+        }
+    >
+
+let PrevUserSetupState =
+      { userSetupState : PrevSetupState
+      , userContactState : < UserContactNone | UserContactInProgress >
+      , userCurrentState : Optional < UserCurrentSetup | UserCurrentContact >
+      }
+
+let PrevUsers = { mapKey : Integer, mapValue : PrevUserSetupState }
+
+-- * New types
+
+-- ** Groups
+
+let ChatSettings =
+      { messagesInQuarantine : Integer
+      , spamCommandAction : < SCAdminsCall | SCPoll >
+      , usersForConsensus : Integer
+      , selfDestroyEnabled : Bool
+      }
+
+let ChatState =
+      { activePolls : List PrevPoll
+      , adminCalls : List PrevAdminCall
+      , allowlist : List Integer
+      , botIsAdmin : Bool
+      , chatAdmins : List Integer
+      , chatAdminsCheckedAt : Optional Date
+      , chatSettings : ChatSettings
+      , chatSetup : PrevChatSetupState
+      , quarantine : List PrevQuarantine
+      }
+
+let Chats = { mapKey : Integer, mapValue : ChatState }
+
+-- ** users
+
+let MenuId =
+    < MenuRoot
+    | ConsensusRoot
+    | SpamCmdRoot
+    | QuarantineRoot
+    | SelfDestroyRoot
+    | Done
+    | Multi : Integer
+    | Consensus : Integer
+    | SpamCmd : < SCPoll | SCAdminsCall >
+    | Quarantine : Integer
+    | BotIsAdmin
+    | SelfDestroy : Bool
+    >
+
+
+let MenuSettings =
+      < MultipleGroupsRoot :
+          { multipleGroupsMenu : List IntTextMap }
+      | MultipleGroupsSelected :
+          { multipleGroupsSelectedChat : Integer
+          , multipleGroupsSelectedSubMenu : MenuId
+          , multipleGroupsSelectedMenu : List IntTextMap
+          }
+      | SingleRoot :
+          { singleGroupChat : Integer
+          , singleGroupSubMenu : MenuId
+          }
+      >
+
+let SetupState =
+    < UserSetupNone
+    | UserSetupInProgress :
+        { userSetupMenu : MenuSettings
+        , userSetupMessageId : Optional Integer
+        }
+    >
+
+let UserSetupState =
+      { userSetupState : SetupState
+      , userContactState : < UserContactNone | UserContactInProgress >
+      , userCurrentState : Optional < UserCurrentSetup | UserCurrentContact >
+      }
+
+let Users = { mapKey : Integer, mapValue : UserSetupState }
+
+-- * migrate
+
+-- ** groups
+
+let migrateChatState
+  = λ(old : PrevChatState)
+  → old ⫽
+      { chatSettings = old.chatSettings
+        ⫽ { selfDestroyEnabled = True }
+      }
+
+let migrateGroups
+  = λ(old : PrevChats)
+  → { mapKey = old.mapKey
+    , mapValue = migrateChatState old.mapValue
+    }
+
+-- ** users
+
+let migrateMenuId
+  = λ(old: PrevMenuId)
+  → merge {
+    MenuRoot = MenuId.MenuRoot,
+    ConsensusRoot = MenuId.ConsensusRoot,
+    SpamCmdRoot = MenuId.SpamCmdRoot,
+    QuarantineRoot = MenuId.QuarantineRoot,
+    Done = MenuId.Done,
+    Multi = λ(v: Integer) → MenuId.Multi v,
+    Consensus = λ(v: Integer) → MenuId.Consensus v,
+    SpamCmd = λ(v: < SCPoll | SCAdminsCall >) → MenuId.SpamCmd v,
+    Quarantine = λ(v: Integer) → MenuId.Quarantine v,
+    BotIsAdmin = MenuId.BotIsAdmin
+  } old
+
+let migrateMenuSettings
+  = λ(oldMenuSettings : PrevMenuSettings)
+  → merge {
+    MultipleGroupsRoot
+      = λ(v: { multipleGroupsMenu : List IntTextMap})
+      → MenuSettings.MultipleGroupsRoot { multipleGroupsMenu = v.multipleGroupsMenu },
+    MultipleGroupsSelected
+      = λ(v: { multipleGroupsSelectedChat : Integer
+             , multipleGroupsSelectedSubMenu : PrevMenuId
+             , multipleGroupsSelectedMenu : List IntTextMap
+             })
+      → MenuSettings.MultipleGroupsSelected
+          { multipleGroupsSelectedSubMenu = migrateMenuId v.multipleGroupsSelectedSubMenu
+          , multipleGroupsSelectedChat = v.multipleGroupsSelectedChat
+          , multipleGroupsSelectedMenu = v.multipleGroupsSelectedMenu
+          },
+    SingleRoot
+      = λ(v: { singleGroupChat : Integer
+             , singleGroupSubMenu : PrevMenuId
+             })
+      → MenuSettings.SingleRoot
+          { singleGroupSubMenu = migrateMenuId v.singleGroupSubMenu
+          , singleGroupChat = v.singleGroupChat
+          }
+  } oldMenuSettings
+
+let migrateSetup
+  = λ(oldSetup : PrevSetupState)
+  → merge {
+  UserSetupNone = SetupState.UserSetupNone,
+  UserSetupInProgress
+    = λ(v: { userSetupMenu : PrevMenuSettings
+           , userSetupMessageId : Optional Integer
+           })
+    → SetupState.UserSetupInProgress
+        { userSetupMenu = migrateMenuSettings v.userSetupMenu
+        , userSetupMessageId = v.userSetupMessageId
+        }
+  } oldSetup
+
+let migrateUserSetup
+  = λ(old : PrevUserSetupState)
+  → old ⫽ { userSetupState = migrateSetup old.userSetupState }
+
+let migrateUsers
+  = λ(oldUser : PrevUsers)
+  → { mapKey = oldUser.mapKey
+    , mapValue = migrateUserSetup oldUser.mapValue
+    }
+
+in { migrateGroups = Prelude/map PrevChats Chats migrateGroups
+   , migrateUsers = Prelude/map PrevUsers Users migrateUsers
+   }
+
+-- Example:
+--
+-- let groups = ./cache/2024-12-04/groups/1733339230.dhall
+-- in (./config/migrations/03-switch-self-destroy.dhall).migrateGroups groups
+--
+--
+-- OK!

--- a/src/Watcher/Bot/Handle/Ban.hs
+++ b/src/Watcher/Bot/Handle/Ban.hs
@@ -62,7 +62,7 @@ handleAdminBan model@BotState{..} chatId ch@ChatState{..} userId messageId admin
             banSpamerInChat model chatId spamer
             let nextState = ch { adminCalls = HM.delete spamerId adminCalls }
             writeCache groups chatId nextState
-            selfDestructReply model chatId (ReplyUserAlreadyBanned spamer)
+            selfDestructReply model chatId ch (ReplyUserAlreadyBanned spamer)
 
 banSpamerInChat :: BotState -> ChatId -> UserInfo -> BotM ()
 banSpamerInChat model chatId spamer = do
@@ -137,7 +137,7 @@ handleBanViaConsensusPoll model@BotState{..} chatId ch@ChatState{..} mVoterId sp
     then do
       updateBlocklistAndMessages model orig
       banSpamerInChat model chatId spamer
-      selfDestructReply model chatId (ReplyUserAlreadyBanned spamer)
+      selfDestructReply model chatId ch (ReplyUserAlreadyBanned spamer)
     else do
       botItself <- liftIO $ readTVarIO self
       let spamerId = SpamerId $! userInfoId spamer
@@ -208,7 +208,7 @@ proceedWithPoll model ch@ChatState{..} chatId spamerId voterId mOrig (pollChange
       closeBanPoll model ch chatId spamerId
       void $ call model $ deleteMessage chatId pollSpamMessageId
       void $ call model $ deleteMessage chatId pollMessageId
-      selfDestructReply model chatId (ReplyConsensus voters)
+      selfDestructReply model chatId ch (ReplyConsensus voters)
 
 handleVoteBan
   :: BotState
@@ -235,7 +235,7 @@ handleVoteBan model chatId ch@ChatState{..} voterId _messageId voteBanId = do
         VoteAgainstBan _ _ -> do
           closeBanPoll model ch chatId spamerId
           void $ call model $ deleteMessage chatId pollMessageId
-          selfDestructReply model chatId (ReplyUserRecovered pollSpamer)
+          selfDestructReply model chatId ch (ReplyUserRecovered pollSpamer)
         VoteForBan _ _ -> do
           let (newPoll, nextChatState) = addVoteToPoll ch voterId spamerId poll
               pollChanged = HS.size (pollVoters poll) /= HS.size (pollVoters newPoll)

--- a/src/Watcher/Bot/Handle/Message.hs
+++ b/src/Watcher/Bot/Handle/Message.hs
@@ -71,7 +71,7 @@ analyseMessage model chatId ch userId message = do
         let spamer = userToUserInfo spamerUser
         updateBlocklistAndMessages model messageInfo
         banSpamerInChat model chatId spamer
-        selfDestructReply model chatId (ReplyUserAlreadyBanned spamer)
+        selfDestructReply model chatId ch (ReplyUserAlreadyBanned spamer)
     else do
       forM_ (messageNewChatMembers message) $ addToQuarantine model chatId ch
       knownSpamMessage <- isKnownSpamMessage model messageInfo

--- a/src/Watcher/Bot/Handle/Unban.hs
+++ b/src/Watcher/Bot/Handle/Unban.hs
@@ -36,7 +36,7 @@ handleUnbanAction model@BotState{..} chatId ch adminId messageId someChatId = do
           userInfo = chatFullInfoToUserInfo c
           userId = userInfoId userInfo
       lookupCache blocklist userId >>= \case
-        Nothing -> selfDestructReply model chatId (ReplyUserHasNotBeenBanned userInfo)
+        Nothing -> selfDestructReply model chatId ch (ReplyUserHasNotBeenBanned userInfo)
         Just BanState{..} -> if HS.singleton chatId == bannedChats
           then do
             end <- liftIO getCurrentTime
@@ -50,7 +50,7 @@ handleUnbanAction model@BotState{..} chatId ch adminId messageId someChatId = do
             let unbanReq = defUnbanChatMember (SomeChatId chatId) userId
             mUnbanResponse <- call model $ unbanChatMember unbanReq
             when ((responseResult <$> mUnbanResponse) == Just True) $ 
-              selfDestructReply model chatId (ReplyUserHasBeenUnbanned userInfo)
+              selfDestructReply model chatId ch (ReplyUserHasBeenUnbanned userInfo)
           else do
             end <- liftIO getCurrentTime
             let evt = (chatEvent end chatId EventGroupUnban)
@@ -63,4 +63,4 @@ handleUnbanAction model@BotState{..} chatId ch adminId messageId someChatId = do
             let unbanReq = defUnbanChatMember (SomeChatId chatId) userId
             mUnbanResponse <- call model $ unbanChatMember unbanReq
             when ((fmap responseResult mUnbanResponse) == Just True) $ 
-              selfDestructReply model chatId (ReplyUserHasBeenUnbanned userInfo)
+              selfDestructReply model chatId ch (ReplyUserHasBeenUnbanned userInfo)

--- a/src/Watcher/Bot/Settings.hs
+++ b/src/Watcher/Bot/Settings.hs
@@ -22,6 +22,7 @@ data GroupSettings = GroupSettings
   { usersForConsensus :: Integer -- ^ Amount of users needed to vote for ban.
   , spamCommandAction :: SpamCommand -- ^ Whether "/spam" enabled or not and what action should be performed.
   , messagesInQuarantine :: Integer -- ^ Amount of messages to keep users in quarantine.
+  , selfDestroyEnabled :: Bool -- ^ Whether self-destructive messages enabled or not.
   } deriving (Generic, FromDhall, ToDhall, Show)
 
 data OwnerGroupSettings = OwnerGroupSettings

--- a/src/Watcher/Bot/State/Chat.hs
+++ b/src/Watcher/Bot/State/Chat.hs
@@ -98,6 +98,7 @@ renderChatState ChatState{..} = Text.unlines
   , "Action on `/spam` command: " <> spamCommandToText spamCommandAction
   , "Quarantine duration (in messages): " <> s2t messagesInQuarantine
   , "Is Bot Admin Already? " <> if botIsAdmin then "✔️" else "❌"
+  , "Send Self-destroyable messages: " <> if selfDestroyEnabled then "✔️" else "❌"
   ]
   where
     GroupSettings {..} = chatSettings

--- a/src/Watcher/Bot/Types/Action.hs
+++ b/src/Watcher/Bot/Types/Action.hs
@@ -44,6 +44,7 @@ data MenuId
   | ConsensusRoot
   | SpamCmdRoot
   | QuarantineRoot
+  | SelfDestroyRoot
   | Done
   -- multiple group
   | Multi ChatId
@@ -55,6 +56,8 @@ data MenuId
   | Quarantine Int
   -- Is Bot Admin
   | BotIsAdmin
+  -- Self destructive messages enabled
+  | SelfDestroy Bool
   deriving (Eq, Show, Read, Generic, FromDhall, ToDhall)
 
 selectNextMenu :: MenuId -> MenuId
@@ -63,6 +66,7 @@ selectNextMenu = \case
   SpamCmd _ -> MenuRoot
   Quarantine _ -> MenuRoot
   BotIsAdmin -> MenuRoot
+  SelfDestroy _ -> MenuRoot
   Done -> MenuRoot
   x -> x
 
@@ -71,6 +75,7 @@ setupMenu = \case
   Consensus  x -> x `elem` [ 2 .. 7 ]
   SpamCmd    _  -> True
   Quarantine x -> x `elem` [ 1 .. 5 ]
+  SelfDestroy _ -> True
   _            -> False
 
 alterSettings :: GroupSettings -> MenuId -> GroupSettings
@@ -78,6 +83,7 @@ alterSettings gs = \case
   Consensus new -> gs { usersForConsensus = fromIntegral new }
   SpamCmd new -> gs { spamCommandAction = new }
   Quarantine new -> gs { messagesInQuarantine = fromIntegral new }
+  SelfDestroy enabled -> gs { selfDestroyEnabled = enabled }
   _ -> gs
 
 


### PR DESCRIPTION
- Add setting which allows to turn self-destroyable messages off.
- Turn it on by default.
- Add migration for both users and groups.