### PR TITLE
Listen for bans by other bot admins

### DIFF
--- a/src/Watcher/Bot/Handle.hs
+++ b/src/Watcher/Bot/Handle.hs
@@ -61,6 +61,10 @@ handleAction (UnbanAction chatId adminId messageId someChatId) model = model <# 
   withCompletedSetup model chatId $ \ch ->
     handleUnbanAction model chatId ch adminId messageId someChatId
 
+handleAction (BotBanAction chatId botUserId bannedMember) model = model <# do
+  withCompletedSetup model chatId $ \ch ->
+    handleBotBanAction model chatId ch botUserId bannedMember
+
 handleAction (VoteBan userId messageId voteBanId) model = model <# do
   let chatId = voteBanIdToChatId voteBanId
   withCompletedSetup model chatId $ \ch ->

--- a/src/Watcher/Bot/Types/Action.hs
+++ b/src/Watcher/Bot/Types/Action.hs
@@ -95,6 +95,7 @@ data Action
   -- ban/undo
   | BanAction ChatId UserId MessageId Message
   | UnbanAction ChatId UserId MessageId SomeChatId
+  | BotBanAction ChatId UserId ChatMember
 
   -- contact
   | SendContactAndQuit ChatId MessageId


### PR DESCRIPTION
Potentially controversial one. Let bot listen of what other bots do and if they ban someone, add spamer to shared blocklist.