### PR TITLE
Support "kicked" chat member status

### DIFF
--- a/src/Watcher/Bot/Parse.hs
+++ b/src/Watcher/Bot/Parse.hs
@@ -126,7 +126,7 @@ handleChatMember settings cmu@ChatMemberUpdated {..} =
     OwnerGroup -> Nothing
     DirectMessage _userId -> Nothing
     PublicGroup chatId userId ->
-      if chatMemberStatus chatMemberUpdatedNewChatMember == "banned"
+      if chatMemberStatus chatMemberUpdatedNewChatMember `elem` ["banned", "kicked"]
         && userIsBot chatMemberUpdatedFrom
         then Just $! BotBanAction chatId userId chatMemberUpdatedNewChatMember
         else Nothing


### PR DESCRIPTION
It was discovered that tba's doc has became outdated at some point. As consequence, handleChatMember might be improved by listening for "kicked" status as well.

See more:
- https://core.telegram.org/bots/api#chatmemberbanned
- https://hackage.haskell.org/package/telegram-bot-api-7.4.2/docs/Telegram-Bot-API-Types-ChatMember.html#t:ChatMember