### PR TITLE
Improve UX of unban

### DIFF
--- a/src/Watcher/Bot/Handle.hs
+++ b/src/Watcher/Bot/Handle.hs
@@ -61,6 +61,9 @@ handleAction (UnbanAction chatId adminId messageId someChatId) model = model <# 
   withCompletedSetup model chatId $ \ch ->
     handleUnbanAction model chatId ch adminId messageId someChatId
 
+handleAction (UnbanGlobally messageId someChatId) model = model <# do
+  handleGlobalUnbanAction model messageId someChatId
+
 handleAction (BotBanAction chatId botUserId bannedMember) model = model <# do
   withCompletedSetup model chatId $ \ch ->
     handleBotBanAction model chatId ch botUserId bannedMember

--- a/src/Watcher/Bot/Parse.hs
+++ b/src/Watcher/Bot/Parse.hs
@@ -109,7 +109,9 @@ handleUnban :: Settings -> Update -> Maybe Action
 handleUnban settings Update{..}
   | Just msg <- asum [ updateMessage, updateEditedMessage ] =
       case messageSentFrom settings msg of
-        OwnerGroup -> Nothing
+        OwnerGroup ->
+          messageText msg >>= tryParseSomeChatId
+          >>= pure . UnbanGlobally (messageMessageId msg)
         DirectMessage _userId -> Nothing
         PublicGroup groupId userId ->
           messageText msg >>= tryParseSomeChatId 

--- a/src/Watcher/Bot/Types/Action.hs
+++ b/src/Watcher/Bot/Types/Action.hs
@@ -95,6 +95,7 @@ data Action
   -- ban/undo
   | BanAction ChatId UserId MessageId Message
   | UnbanAction ChatId UserId MessageId SomeChatId
+  | UnbanGlobally MessageId SomeChatId
   | BotBanAction ChatId UserId ChatMember
 
   -- contact

--- a/src/Watcher/Bot/Types/MessageFrom.hs
+++ b/src/Watcher/Bot/Types/MessageFrom.hs
@@ -1,7 +1,7 @@
 module Watcher.Bot.Types.MessageFrom where
 
 import Data.Coerce (coerce)
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (isJust)
 import Telegram.Bot.API
 
 import Watcher.Bot.Settings


### PR DESCRIPTION
- Absence of banned chats should be counted for a global unban in a single group.
- Add `/unban` capability for owners to unban user globally everywhere user is banned.