### PR TITLE
Check for known spamers / quarantine before entering logic branches

### DIFF
--- a/src/Watcher/Bot/Parse.hs
+++ b/src/Watcher/Bot/Parse.hs
@@ -40,7 +40,7 @@ updateToAction settings@Settings{..} update
   | isCallback update = handleCallback settings =<< updateCallbackQuery update
 
   -- chat member
-  | isChatMember update = Just $! Debug update
+  | isChatMember update = handleChatMember settings =<< updateChatMember update
 
   -- regular messages and the rest stuff
   | otherwise = handleMessage settings update


### PR DESCRIPTION
- check for `messageNewChatMembers` before the actual check for message text.
- restore `updateChatMember` (no logs gathered)