### PR TITLE
Improve response of `/getChatMember`

### DIFF
--- a/src/Watcher/Bot/Handle.hs
+++ b/src/Watcher/Bot/Handle.hs
@@ -32,8 +32,8 @@ handleAction (DebugCallback q) model = model <# do
 handleAction (Tuning update) model = model <# do
   handleTuning model update
 
-handleAction (GetChatMember chatId userId) model = model <# do
-  handleGetChatMember model chatId userId
+handleAction (GetChatMember chatId) model = model <# do
+  handleGetChatMember model chatId 
 
 handleAction (Analyse chatId userId message) model = model <# do
   handleAnalyseMessage model chatId userId message

--- a/src/Watcher/Bot/Handle/Message.hs
+++ b/src/Watcher/Bot/Handle/Message.hs
@@ -69,7 +69,6 @@ analyseMessage model chatId ch userId message = do
   if userAlreadyBanned
     -- if user has banned globally but was unbanned locally, bot will allow such a user
     then do
-      liftIO $ log' ("analyseMessage: already banned" :: Text, message)
       unless (HS.member userId (allowlist ch)) $ do
         forM_ (messageFrom message) $ \spamerUser -> do
           let spamer = userToUserInfo spamerUser

--- a/src/Watcher/Bot/Parse.hs
+++ b/src/Watcher/Bot/Parse.hs
@@ -81,18 +81,18 @@ handleTuning settings upd@Update{..}
   | otherwise = Nothing
 
 handleGetChatMember :: Settings -> Update -> Maybe Action
-handleGetChatMember settings upd@Update{..}
+handleGetChatMember settings Update{..}
   | Just msg <- asum [ updateMessage, updateEditedMessage ] =
       case messageSentFrom settings msg of
         OwnerGroup ->
           let cmdAsList = Text.words $ fromMaybe "" $ messageText msg
               textToInteger = readMaybe @Integer . Text.unpack
-              (mChatId, mUserId) = case cmdAsList of
-                _cmd : chatId : userId : _ ->
-                  (textToInteger chatId, textToInteger userId)
-                _ -> (Nothing, Nothing)
-          in GetChatMember <$> (ChatId <$> mChatId) <*> (UserId <$> mUserId)
+              mChatId = case cmdAsList of
+                _cmd : chatId : _ -> textToInteger chatId
+                _ -> Nothing
+          in GetChatMember <$> (ChatId <$> mChatId)
         _ -> Nothing
+  | otherwise = Nothing
 
 -- | Some user requsted @/ban@. Let see what we can do about it:
 --

--- a/src/Watcher/Bot/Types/Action.hs
+++ b/src/Watcher/Bot/Types/Action.hs
@@ -122,7 +122,7 @@ data Action
   -- Message
   | Analyse ChatId UserId Message
   | Tuning Update
-  | GetChatMember ChatId UserId
+  | GetChatMember ChatId 
 
   -- Dump
   | Dump Message


### PR DESCRIPTION
- Produce output for entire chat quarantine, just metadata: user status in the chat and amount of received messages
- Remove debug for already banned users