### PR TITLE
Add one-time quarantine worker (autoban)

### DIFF
--- a/src/Watcher/Bot/Cache.hs
+++ b/src/Watcher/Bot/Cache.hs
@@ -97,6 +97,9 @@ alterCache
 alterCache cache key modifier =
   liftIO $! atomically $! modifyTVar' cache $! HM.alter modifier key
 
+readCache
+  :: MonadIO m => TVar cache -> m cache
+readCache = liftIO . atomically . readTVar
 
 removeDirectoryIfExist :: FilePath -> IO ()
 removeDirectoryIfExist dir = do


### PR DESCRIPTION
If it turns out to be success, schedule it to run periodically.
- Traverse all chat states and clean up quarantine. According to Telegram Bot API "kicked"  means user is a spammer and it's banned, so no need to keep spammers in quarantine.
- Moreover, remove redundant exception handler from `call` and `liftClientM` which introduces unsafety for this bot.