### PR TITLE
Add logger

### DIFF
--- a/src/Watcher/Bot/Handle/Contact.hs
+++ b/src/Watcher/Bot/Handle/Contact.hs
@@ -40,6 +40,7 @@ checkUserContact model@BotState{..} userId msg = do
 
 contactUser :: BotState -> Message -> BotM ()
 contactUser model origMsg = do
+  let ?model = model
   forM_ (messageReplyToMessage origMsg) $ \msg -> do
     let fromChatId = chatId $ messageChat origMsg
         tryExtractChatIdFromForward m = join $ forM (messageForwardOrigin m) $ \case
@@ -69,6 +70,7 @@ contactUser model origMsg = do
 
 collectFeedback :: BotState -> ChatId -> BotM ()
 collectFeedback model@BotState{..} chatId = do
+  let ?model = model
   mResponse <- call model (getChat $ SomeChatId chatId)
   forM_ mResponse $ \Response{..} -> when responseOk $ do
     let Settings{..} = botSettings

--- a/src/Watcher/Bot/Handle/Message.hs
+++ b/src/Watcher/Bot/Handle/Message.hs
@@ -42,6 +42,7 @@ handleAnalyseMessage model@BotState{..} chatId userId message = do
 
 handleTuning :: BotState -> Update -> BotM ()
 handleTuning model@BotState{..} Update{..} = do
+  let ?model = model
   let mMsg = asum [ updateMessage, updateEditedMessage ]
   forM_ mMsg $ \origMsg -> do
     void $ call model

--- a/src/Watcher/Bot/Handle/Setup.hs
+++ b/src/Watcher/Bot/Handle/Setup.hs
@@ -85,6 +85,7 @@ handleNavigate model@BotState{..} userChatId messageId menuId = do
 
 refreshChatAdmins :: BotState -> ChatId -> BotM ()
 refreshChatAdmins model@BotState{..} chatId = do
+  let ?model = model
   now <- liftIO getCurrentTime
   mChatState <- lookupCache groups chatId
   let st = fromMaybe (newChatState botSettings) mChatState
@@ -159,6 +160,7 @@ setSingleRoot BotState{..} userId chatId = alterCache users userId go
 --
 initGroupSetupMaybe :: BotState -> UserId -> (ChatId, Maybe Text) -> BotM Bool
 initGroupSetupMaybe model@BotState{..} userId (chatId, _mChatname) = do
+  let ?model = model
   now <- liftIO getCurrentTime
   mChatState <- lookupCache groups chatId
 
@@ -171,7 +173,7 @@ initGroupSetupMaybe model@BotState{..} userId (chatId, _mChatname) = do
       case mResponse of
         Nothing -> pure False
         Just Response{..} -> if not responseOk
-          then liftIO (log' @String "Cannot retrieve admins") >> pure False
+          then liftIO (logT "Cannot retrieve admins") >> pure False
           else do
           let chatAdmins = membersToAdminIds responseResult
               newState = (newChatState botSettings)

--- a/src/Watcher/Bot/ModelChecker.hs
+++ b/src/Watcher/Bot/ModelChecker.hs
@@ -21,7 +21,6 @@ import Watcher.Bot.Handle.Message
 import Watcher.Bot.Settings
 import Watcher.Bot.State
 import Watcher.Bot.State.Chat
-import Watcher.Bot.Utils
 
 data ExportedChat = ExportedChat
   { exportedChatId :: Integer
@@ -126,6 +125,8 @@ instance ToRecord ChatExportTuningEntry where
 
 processChatExport :: FilePath -> FilePath -> Maybe Int -> IO ()
 processChatExport inputFile outputFile mFromId = do
+  botState <- newBotState =<< loadDefaultSettings
+  let ?model = botState
   eitherDecodeFileStrict' inputFile >>= \case
     Left err -> log' err
     Right result -> tuneChatExport outputFile mFromId result

--- a/src/Watcher/Bot/Utils.hs
+++ b/src/Watcher/Bot/Utils.hs
@@ -9,15 +9,5 @@ import qualified Data.Text.IO as Text
 s2t :: Show a => a -> Text
 s2t = Text.pack . show
 
-log' :: Show a => a -> IO ()
-log' x = do
-  now <- getCurrentTime
-  putStrLn $ show now <> ": " <> show x
-
-logT :: Text -> IO ()
-logT txt = do
-  now <- getCurrentTime
-  Text.putStrLn $ s2t now <> ": " <> txt
-
 notLongAgoEnough :: UTCTime -> UTCTime -> Bool
 notLongAgoEnough prev next = diffUTCTime next prev > 86400.0

--- a/watcher-bot.cabal
+++ b/watcher-bot.cabal
@@ -96,6 +96,7 @@ library
     default-extensions: BlockArguments
                       , DeriveAnyClass
                       , DerivingStrategies
+                      , ImplicitParams
                       , LambdaCase
                       , OverloadedStrings
                       , RecordWildCards
@@ -115,6 +116,7 @@ library
                     , exceptions
                     , filepath
                     , hashable
+                    , katip
                     , mtl
                     , optparse-applicative
                     , pretty


### PR DESCRIPTION
Right now some of output has been lost due to buffering, worker threads and other causes. This PR intends to fix it by replacing `log'` with `katip`.