### PR TITLE
Schedule `getChatMember` check with 5-min delay

### DIFF
--- a/config/default.dhall
+++ b/config/default.dhall
@@ -105,7 +105,7 @@ Extra commands:
     , usersPath = "users"
     , blocklistPath = "blocklist"
     , spamMessagesPath = "spam_messages"
-    , selfDestructionSetPath = "self_destruct_set"
+    , eventSetPath = "triggered_events"
     }
 , analytics =
     { analyticsDir = "./bigdata"

--- a/src/Watcher/Bot/Handle.hs
+++ b/src/Watcher/Bot/Handle.hs
@@ -7,6 +7,7 @@ import Telegram.Bot.API
 import Telegram.Bot.Simple
 
 import Watcher.Bot.Handle.Ban
+import Watcher.Bot.Handle.ChatMember
 import Watcher.Bot.Handle.Contact
 import Watcher.Bot.Handle.Debug
 import Watcher.Bot.Handle.Dump
@@ -114,5 +115,10 @@ handleAction (Dump _message) model = model <# do
 -- | Async action: part of self-destruct mechanics. Bot will delete the message if possible.
 handleAction (DeleteMessage chatId messageId) model = model <# do
   void $ call $ deleteMessage chatId messageId
+  pure ()
+
+-- | Async action: check user member, if kicked, ban them everywhere too.
+handleAction (CheckChatMember chatId userId) model = model <# do
+  void $ handleCheckChatMember chatId userId
   pure ()
 

--- a/src/Watcher/Bot/Handle/ChatMember.hs
+++ b/src/Watcher/Bot/Handle/ChatMember.hs
@@ -1,0 +1,21 @@
+module Watcher.Bot.Handle.ChatMember where
+
+import Control.Monad (when)
+import Control.Monad.IO.Class (MonadIO)
+import Data.Text (Text)
+import Telegram.Bot.API
+
+import Watcher.Bot.State
+import Watcher.Bot.Handle.Ban
+import Watcher.Bot.Handle.Message
+
+handleCheckChatMember :: (WithBotState, MonadIO m) => ChatId -> UserId -> m Text
+handleCheckChatMember chatId userId = do
+  mResponse <- call $ getChatMember (SomeChatId chatId) userId
+
+  let status = maybe "unknown" (chatMemberStatus . responseResult) mResponse :: Text
+  when (status == "kicked") $ do
+    updateBlocklist chatId userId Nothing
+    endQuarantineForUser chatId userId
+
+  pure status

--- a/src/Watcher/Bot/Handle/Dump.hs
+++ b/src/Watcher/Bot/Handle/Dump.hs
@@ -18,4 +18,4 @@ dumpAllCachesOnce = do
   dumpCache now usersPath users
   dumpCache now blocklistPath blocklist
   dumpCache now spamMessagesPath spamMessages
-  dumpCache now selfDestructionSetPath selfDestructionSet
+  dumpCache now eventSetPath eventSet

--- a/src/Watcher/Bot/Settings.hs
+++ b/src/Watcher/Bot/Settings.hs
@@ -60,7 +60,7 @@ data StorageSettings = StorageSettings
   , usersPath :: FilePath
   , blocklistPath :: FilePath
   , spamMessagesPath :: FilePath
-  , selfDestructionSetPath :: FilePath
+  , eventSetPath :: FilePath
   } deriving (Generic, FromDhall, ToDhall, Show)
 
 data AnalyticsSettings = AnalyticsSettings

--- a/src/Watcher/Bot/Trigger.hs
+++ b/src/Watcher/Bot/Trigger.hs
@@ -1,0 +1,36 @@
+module Watcher.Bot.Trigger where
+
+import Control.Concurrent.STM (atomically, modifyTVar', readTVar)
+import Control.Monad (forever)
+import Data.Time (diffUTCTime, getCurrentTime)
+
+import qualified Data.Set as Set
+
+import Watcher.Bot.State
+import Watcher.Bot.Types
+
+processTriggeredEvents :: WithBotState => (Action -> IO ()) -> IO ()
+processTriggeredEvents fun = forever $! do
+  let BotState{..} = ?model
+  queue <- atomically $ readTVar eventSet
+  case Set.lookupMin queue of
+    Nothing -> wait 1
+    Just evt -> do
+      atomically $! modifyTVar' eventSet $! Set.delete evt
+      now <- getCurrentTime
+      case evt of
+        SelfDestructMessageEvent SelfDestructMessage{..} ->
+          if selfDestructMessageTime < now
+            then fun (DeleteMessage selfDestructMessageChatId selfDestructMessageId)
+            else do
+              let sec = diffUTCTime now selfDestructMessageTime
+              wait $ round sec
+              fun (DeleteMessage selfDestructMessageChatId selfDestructMessageId)
+        UserChatMemberCheckEvent UserChatMemberCheck{..} -> do
+          let action = CheckChatMember userChatMemberCheckChatId userChatMemberCheckUserId
+          if userChatMemberCheckTime < now
+            then fun action
+            else do
+             let sec = diffUTCTime now userChatMemberCheckTime
+             wait $ round sec
+             fun action

--- a/src/Watcher/Bot/Types/Action.hs
+++ b/src/Watcher/Bot/Types/Action.hs
@@ -113,6 +113,7 @@ data Action
 
   -- Background
   | DeleteMessage ChatId MessageId
+  | CheckChatMember ChatId UserId
 
   -- Help
   | DirectMessageHelp UserId MessageId

--- a/watcher-bot.cabal
+++ b/watcher-bot.cabal
@@ -64,6 +64,7 @@ library
                       Watcher.Bot.Cache
                       Watcher.Bot.Handle
                       Watcher.Bot.Handle.Ban
+                      Watcher.Bot.Handle.ChatMember
                       Watcher.Bot.Handle.Contact
                       Watcher.Bot.Handle.Debug
                       Watcher.Bot.Handle.Dump
@@ -78,6 +79,7 @@ library
                       Watcher.Bot.State
                       Watcher.Bot.State.Chat
                       Watcher.Bot.State.User
+                      Watcher.Bot.Trigger
                       Watcher.Bot.Types
                       Watcher.Bot.Types.Action
                       Watcher.Bot.Types.ChatInfo


### PR DESCRIPTION
- When user has joined and not recognised as a spammer, schedule 5min delay check whether it was banned or not.
- Extend set with self-destructive messages for that purpose.