### PR TITLE
Support unbans by username + migrations

### DIFF
--- a/config/common/map.dhall
+++ b/config/common/map.dhall
@@ -25,4 +25,12 @@ Examples:
               → List/fold a xs list (λ(x : a) → cons (f x))
             )
 
-in  map
+    let Map
+        : Type → Type → Type
+        = λ(k : Type) → λ(v : Type) → List { mapKey : k, mapValue : v }
+
+    let Entry
+        : Type → Type → Type
+        = λ(k : Type) → λ(v : Type) → { mapKey : k, mapValue : v }
+
+in  { Map, Entry, map }

--- a/config/migrations/04-extend-user-context-for-unbans.dhall
+++ b/config/migrations/04-extend-user-context-for-unbans.dhall
@@ -1,0 +1,255 @@
+-- * common
+
+let Prelude = ../common/map.dhall
+let Entry = Prelude.Entry
+let Map = Prelude.Map
+let map = Prelude.map
+
+let UTCTime = { date : Date, time : Time, timeZone : TimeZone }
+
+-- * previous
+
+-- ** blocklist
+
+let PrevBanState
+  = { bannedMessages : List Text
+    , bannedChats : List Integer
+    }
+
+let PrevBlocklist = List (Map Integer PrevBanState)
+
+-- ** groups
+
+let PrevChatSettings =
+      { messagesInQuarantine : Integer
+      , spamCommandAction : < SCAdminsCall | SCPoll >
+      , usersForConsensus : Integer
+      , selfDestroyEnabled : Bool
+      }
+
+let PrevChatSetupState =
+      < SetupCompleted :
+          { setupCompletedAt : UTCTime
+          , setupCompletedByAdmin : Integer
+          }
+      | SetupInProgress :
+          { setupModifiedAt : UTCTime
+          , setupModifiedByAdmin : Integer
+          }
+      | SetupNone
+      >
+
+let PrevUserInfo =
+      { userInfoId : Integer
+      , userInfoFirstName : Text
+      , userInfoLastName : Optional Text
+      , userInfoLink : Text
+      }
+
+let PrevChatInfo =
+      { chatInfoId : Integer
+      , chatInfoName : Text
+      , chatInfoTitle : Optional Text
+      , chatInfoBio : Optional Text
+      , chatInfoEmojiStatusCustomEmojiId : Optional Text
+      , chatInfoBackgroundCustomEmojiId : Optional Text
+      }
+
+let PrevMessageInfo =
+      { messageInfoId : Integer
+      , messageInfoThreadId : Optional Integer
+      , messageInfoText : Optional Text
+      , messageInfoFrom : Optional PrevUserInfo
+      , messageInfoChat : PrevChatInfo
+      }
+
+let PrevQuarantine =
+      { _1 : Optional PrevChatInfo
+      , _2 : List Bytes
+      }
+
+let PrevAdminCall =
+      { _1 : PrevUserInfo
+      , _2 : PrevMessageInfo
+      }
+
+let PrevPoll =
+      { pollMessageId : Integer
+      , pollSpamMessageId : Integer
+      , pollVoters : List Integer
+      , pollSpamer : PrevUserInfo
+      }
+
+let PrevChatState =
+      { chatSettings : PrevChatSettings
+      , chatAdmins : List Integer
+      , chatAdminsCheckedAt : Optional Date
+      , chatSetup : PrevChatSetupState
+      , quarantine : Map Integer PrevQuarantine
+      , activePolls : Map Integer PrevPoll
+      , adminCalls : Map Integer PrevAdminCall
+      , allowlist : List Integer
+      , botIsAdmin : Bool
+      }
+
+let PrevChats = Map Integer PrevChatState
+
+-- ** events
+
+let PrevSelfDestructMessage =
+      { selfDestructMessageChatId : Integer
+      , selfDestructMessageId : Integer
+      , selfDestructMessageTime :
+          { date : Date, time : Time, timeZone : TimeZone }
+      }
+
+let PrevUserChatMemberCheck =
+      { userChatMemberCheckChatId : Integer
+      , userChatMemberCheckUserId : Integer
+      , userChatMemberCheckTime :
+          { date : Date, time : Time, timeZone : TimeZone }
+      }
+
+let PrevEvent =
+  < SelfDestructMessageEvent : PrevSelfDestructMessage
+  | UserChatMemberCheckEvent : PrevUserChatMemberCheck
+  >
+
+-- * new
+
+-- ** groups
+
+let UserInfo =
+      { userInfoId : Integer
+      , userInfoFirstName : Text
+      , userInfoLastName : Optional Text
+      , userInfoUsername : Optional Text
+      , userInfoLink : Text
+      }
+
+
+let MessageInfo =
+      { messageInfoId : Integer
+      , messageInfoThreadId : Optional Integer
+      , messageInfoText : Optional Text
+      , messageInfoFrom : Optional UserInfo
+      , messageInfoChat : PrevChatInfo
+      }
+
+let AdminCall =
+      { _1 : UserInfo
+      , _2 : MessageInfo
+      }
+
+let Poll =
+      { pollMessageId : Integer
+      , pollSpamMessageId : Integer
+      , pollVoters : List Integer
+      , pollSpamer : UserInfo
+      }
+
+let ChatState =
+      { chatSettings : PrevChatSettings
+      , chatAdmins : List Integer
+      , chatAdminsCheckedAt : Optional Date
+      , chatSetup : PrevChatSetupState
+      , quarantine : Map Integer PrevQuarantine
+      , activePolls : Map Integer Poll
+      , adminCalls : Map Integer AdminCall
+      , allowlist : List Integer
+      , botIsAdmin : Bool
+      }
+      
+let Chats = Map Integer ChatState
+
+-- ** Events
+
+let UserChatMemberCheck =
+      { userChatMemberCheckChatId : Integer
+      , userChatMemberCheckUserInfo : UserInfo
+      , userChatMemberCheckTime :
+          { date : Date, time : Time, timeZone : TimeZone }
+      }
+
+let Event =
+  < SelfDestructMessageEvent : PrevSelfDestructMessage
+  | UserChatMemberCheckEvent : UserChatMemberCheck
+  >
+
+-- * migrate :)
+
+let migrateBlocklist
+  = λ(old: PrevBlocklist)
+  → { spamerBans = old
+    , spamerUsernames = [] : List { mapKey : Text, mapValue : Integer }
+    }
+
+let migrateUserInfo
+  = λ(old: PrevUserInfo)
+  → old ⫽ { userInfoUsername = None Text }
+
+let migrateOptionalUserInfo
+  = λ(old: Optional PrevUserInfo)
+  → merge {
+      None = None UserInfo,
+      Some = λ(v: PrevUserInfo) → Some (migrateUserInfo v)
+    } old
+
+let migrateActivePolls
+  = λ(old: Entry Integer PrevPoll)
+  → { mapKey = old.mapKey
+    , mapValue = old.mapValue ⫽ { pollSpamer = migrateUserInfo old.mapValue.pollSpamer }
+    }
+
+let migrateAdminCalls
+  = λ(old: Entry Integer PrevAdminCall)
+  → { mapKey = old.mapKey
+    , mapValue =
+        { _1 = migrateUserInfo old.mapValue._1
+        , _2 = old.mapValue._2
+          ⫽ { messageInfoFrom = migrateOptionalUserInfo old.mapValue._2.messageInfoFrom }
+        }
+    }
+
+let migrateChatState
+  = λ(old: PrevChatState)
+  → old ⫽ { adminCalls = map
+              (Entry Integer PrevAdminCall) (Entry Integer AdminCall)
+              migrateAdminCalls old.adminCalls
+          , activePolls = map
+              (Entry Integer PrevPoll) (Entry Integer Poll)
+              migrateActivePolls old.activePolls
+          }
+let migrateGroups
+  = λ(old: Entry Integer PrevChatState)
+  → { mapKey = old.mapKey
+    , mapValue = migrateChatState old.mapValue
+    }
+
+let makeUserInfo
+  = λ(old: Integer)
+  → { userInfoId = old
+    , userInfoFirstName = ""
+    , userInfoLastName = None Text
+    , userInfoUsername = None Text
+    , userInfoLink = "<a href='tg://chat?id=${Integer/show old}'>N/A</a>"
+    }
+
+let migrateEvents
+  = λ(old: PrevEvent)
+  → merge { 
+      SelfDestructMessageEvent
+        = λ(old : PrevSelfDestructMessage) → Event.SelfDestructMessageEvent old,
+      UserChatMemberCheckEvent
+        = λ(old : PrevUserChatMemberCheck) → Event.UserChatMemberCheckEvent
+            { userChatMemberCheckChatId = old.userChatMemberCheckChatId
+            , userChatMemberCheckUserInfo = makeUserInfo old.userChatMemberCheckUserId
+            , userChatMemberCheckTime = old.userChatMemberCheckTime
+            }
+    } old
+
+in { migrateBlocklist
+   , migrateGroups =
+       map (Entry Integer PrevChatState) (Entry Integer ChatState) migrateGroups
+   , migrateEvents = map PrevEvent Event migrateEvents
+   }

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -11,6 +11,8 @@ mkdir -p ./log
 # normalise config
 dhall --output ./config/settings.dhall <<< ./config/default.dhall
 
+watcher-bot migration
+
 watcher-bot bot +RTS -A64m -AL256m -qn2 -RTS >> log/watcher-bot.log 2>&1 &
 
 # write PID to file

--- a/src/Telegram/Bot/API/Names.hs
+++ b/src/Telegram/Bot/API/Names.hs
@@ -38,3 +38,9 @@ makeLink entityType idSelector usernameSelector getName v = case usernameSelecto
     , "</a>"
     ]
   Just username -> Text.cons '@' username
+
+normaliseUsername :: Text -> Maybe Text
+normaliseUsername txt = case Text.uncons txt of
+  Nothing -> Nothing
+  Just ('@', _) -> Just txt
+  Just (_, _)   -> Just $ Text.cons '@' txt

--- a/src/Watcher/Bot/Handle.hs
+++ b/src/Watcher/Bot/Handle.hs
@@ -118,7 +118,7 @@ handleAction (DeleteMessage chatId messageId) model = model <# do
   pure ()
 
 -- | Async action: check user member, if kicked, ban them everywhere too.
-handleAction (CheckChatMember chatId userId) model = model <# do
-  void $ handleCheckChatMember chatId userId
+handleAction (CheckChatMember chatId user) model = model <# do
+  void $ handleCheckChatMember chatId user
   pure ()
 

--- a/src/Watcher/Bot/Handle/ChatMember.hs
+++ b/src/Watcher/Bot/Handle/ChatMember.hs
@@ -5,17 +5,20 @@ import Control.Monad.IO.Class (MonadIO)
 import Data.Text (Text)
 import Telegram.Bot.API
 
-import Watcher.Bot.State
 import Watcher.Bot.Handle.Ban
 import Watcher.Bot.Handle.Message
+import Watcher.Bot.State
+import Watcher.Bot.Types
 
-handleCheckChatMember :: (WithBotState, MonadIO m) => ChatId -> UserId -> m Text
-handleCheckChatMember chatId userId = do
+handleCheckChatMember
+  :: (WithBotState, ToUserInfo user, MonadIO m) => ChatId -> user -> m Text
+handleCheckChatMember chatId user = do
+  let userId = toUserId user
   mResponse <- call $ getChatMember (SomeChatId chatId) userId
 
   let status = maybe "unknown" (chatMemberStatus . responseResult) mResponse :: Text
   when (status == "kicked") $ do
-    updateBlocklist chatId userId Nothing
+    updateBlocklist chatId (toUserInfo user) Nothing
     endQuarantineForUser chatId userId
 
   pure status

--- a/src/Watcher/Bot/Trigger.hs
+++ b/src/Watcher/Bot/Trigger.hs
@@ -27,7 +27,7 @@ processTriggeredEvents fun = forever $! do
               wait $ round sec
               fun (DeleteMessage selfDestructMessageChatId selfDestructMessageId)
         UserChatMemberCheckEvent UserChatMemberCheck{..} -> do
-          let action = CheckChatMember userChatMemberCheckChatId userChatMemberCheckUserId
+          let action = CheckChatMember userChatMemberCheckChatId userChatMemberCheckUserInfo
           if userChatMemberCheckTime < now
             then fun action
             else do

--- a/src/Watcher/Bot/Types/Action.hs
+++ b/src/Watcher/Bot/Types/Action.hs
@@ -6,6 +6,7 @@ import Telegram.Bot.API
 
 import Watcher.Bot.Settings
 import Watcher.Bot.Types.Common
+import Watcher.Bot.Types.UserInfo
 
 data VoteBanId
   = VoteForBan ChatId SpamerId
@@ -113,7 +114,7 @@ data Action
 
   -- Background
   | DeleteMessage ChatId MessageId
-  | CheckChatMember ChatId UserId
+  | CheckChatMember ChatId UserInfo
 
   -- Help
   | DirectMessageHelp UserId MessageId

--- a/src/Watcher/Bot/Types/UserInfo.hs
+++ b/src/Watcher/Bot/Types/UserInfo.hs
@@ -14,8 +14,18 @@ data UserInfo = UserInfo
   { userInfoId :: UserId
   , userInfoFirstName :: Text
   , userInfoLastName :: Maybe Text
+  , userInfoUsername :: Maybe Text
   , userInfoLink :: Text
   } deriving (Show, Eq, Generic, FromDhall, ToDhall)
+
+makeUserInfo :: UserId -> UserInfo
+makeUserInfo uid = UserInfo
+  { userInfoId = uid
+  , userInfoFirstName = ""
+  , userInfoLastName = Nothing
+  , userInfoUsername = Nothing
+  , userInfoLink = makeLink "user" (coerce @UserId @Integer) (const Nothing) (const "N/A") uid
+  }
 
 userToUserInfo :: User -> UserInfo
 userToUserInfo u@User{..} = UserInfo
@@ -23,6 +33,7 @@ userToUserInfo u@User{..} = UserInfo
   , userInfoFirstName = userFirstName
   , userInfoLastName = userLastName
   , userInfoLink = makeUserLink u
+  , userInfoUsername = userUsername
   }
 
 chatFullInfoToUserInfo :: ChatFullInfo -> UserInfo
@@ -32,4 +43,25 @@ chatFullInfoToUserInfo cf = UserInfo
   , userInfoLastName = chatFullInfoLastName cf
   , userInfoLink = makeLink "user"
       (coerce @_ @Integer . chatFullInfoId) chatFullInfoUsername getChatFullInfoName cf
+  , userInfoUsername = chatFullInfoUsername cf
   }
+
+class ToUserInfo a where
+  toUserInfo :: a -> UserInfo
+  toUserId :: a -> UserId
+
+instance ToUserInfo User where
+  toUserInfo = userToUserInfo
+  toUserId = userId
+
+instance ToUserInfo ChatFullInfo where
+  toUserInfo = chatFullInfoToUserInfo
+  toUserId = coerce @_ @UserId . chatFullInfoId
+
+instance ToUserInfo UserInfo where
+  toUserInfo = id
+  toUserId = userInfoId
+
+instance ToUserInfo UserId where
+  toUserInfo = makeUserInfo
+  toUserId = id

--- a/src/Watcher/Migration.hs
+++ b/src/Watcher/Migration.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+module Watcher.Migration where
+
+import Control.Exception (SomeException, evaluate, try)
+import Data.Char (isDigit)
+import Data.List (sortOn)
+import Data.Ord (Down (..))
+import Data.Kind (Type)
+import Data.Maybe (fromMaybe, listToMaybe)
+import Dhall
+import System.Directory (listDirectory)
+import System.FilePath ((</>), (<.>), isExtensionOf, takeBaseName, takeDirectory)
+import Text.Read (readMaybe)
+
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+
+import Watcher.Bot.Cache
+import Watcher.Bot.Settings
+import Watcher.Bot.State
+
+findRecentMigration :: FilePath -> IO FilePath
+findRecentMigration dir = do
+  let migrationNumber file = (, file) $ readMaybe @Int $ takeWhile isDigit file
+  contents <- filter (isExtensionOf ".dhall") <$> listDirectory dir
+  pure
+    . (dir </>)
+    . fromMaybe (error "No migrations found")
+    . listToMaybe
+    . sortOn (Down . migrationNumber)
+    $ contents
+
+nextCachePath :: FilePath -> FilePath
+nextCachePath cachePath =
+  let dir = takeDirectory cachePath
+      base = takeBaseName cachePath
+      next = succ $ fromMaybe 0 $ readMaybe @Int (takeWhile isDigit base)
+      remainder = dropWhile isDigit base
+  in dir </> (show next <> remainder) <.> "dhall"
+
+migrate :: IO ()
+migrate = do
+  Settings {..} <- loadDefaultSettings
+  let StorageSettings {..} = storage
+
+  recentMigrationPath <- findRecentMigration "./config/migrations"
+  putStrLn $ "The most recent migration: " <> recentMigrationPath
+
+  let run
+        :: forall (a :: Type) . (FromDhall a, ToDhall a)
+        => (Text, FilePath) -> IO ()
+      run = runMigration @a recentMigrationPath
+
+  run @Admins ("migrateAdmins", adminsPath)
+  run @Blocklist ("migrateBlocklist", blocklistPath)
+  run @Groups ("migrateGroups", groupsPath)
+  run @SpamMessages ("migrateSpamMessages", spamMessagesPath)
+  run @Users ("migrateUsers", usersPath)
+  run @Events ("migrateEvents", eventSetPath)
+
+runMigration
+  :: forall (a :: Type). (FromDhall a, ToDhall a)
+  => FilePath -> ( Text, FilePath) -> IO ()
+runMigration migrationPath (migrateFun, cachePathPiece) = do
+  let getRecentCachePath path = do
+        mCachePath <- getRecentCacheFilePathMaybe path
+        pure $ fromMaybe (error $ "cache not found: " <> cachePathPiece) mCachePath
+  eAdmins <- try $ do
+    putStr $ "Checking " <> cachePathPiece
+    cachePath <- getRecentCachePath cachePathPiece
+    load @a (Text.pack cachePath) >>= evaluate
+  case eAdmins of
+    Right _ -> putStr $ "\tOK\n"
+    Left (_err :: SomeException) -> do
+      putStr $ "\tMigrating...\n"
+      cachePath <- getRecentCachePath cachePathPiece
+      putStrLn $ "The most recent cache: " <> cachePath
+      let migratedCachePath = nextCachePath cachePath
+      applyMigration @a migrateFun migrationPath cachePath migratedCachePath
+      putStrLn $ "Output has been written to: " <> migratedCachePath
+
+applyMigration
+  :: forall a. (FromDhall a, ToDhall a)
+  => Text -> FilePath -> FilePath -> FilePath -> IO ()
+applyMigration fun migration cachePath outputCachePath = do
+  let expr = Text.concat
+        [ "let cache = ", Text.pack cachePath
+        , " in (", Text.pack migration, ").", fun, " cache"
+        ]
+  content <- evaluate =<< load @a expr
+  let txt = renderPretty content
+  Text.writeFile outputCachePath txt
+  putStrLn "Migration applied: OK"

--- a/watcher-bot.cabal
+++ b/watcher-bot.cabal
@@ -88,6 +88,7 @@ library
                       Watcher.Bot.Types.MessageFrom
                       Watcher.Bot.Types.UserInfo
                       Watcher.Bot.Utils
+                      Watcher.Migration
                       Watcher.Orphans
                       Telegram.Bot.API.Names
 


### PR DESCRIPTION
- Extend `UserInfo` with username.
- Extend `UserMemberCheck` with `UserInfo`
- Extend `blocklist` with extra index where you can lookup `UserId` by username.
- To automate tedious process of migrations, implement migration worker which handles only the most recent migration via applying it for the most recent cache.

Closes #37.