### PR TITLE
Lookup for username to obtiain `UserId` during unban

### DIFF
--- a/src/Watcher/Bot/Reply.hs
+++ b/src/Watcher/Bot/Reply.hs
@@ -40,6 +40,7 @@ data ReplyAnswerType
   | ReplyUserHasBeenUnbanned { replyUserHasBeenUnbanned :: UserInfo }
   | ReplyUserAlreadyBanned { replyUserAlreadyBanned :: UserInfo }
   | ReplyUserRecovered { replyUserRecovered :: UserInfo }
+  | ReplyUnknownUsername { replyUnknownUsername :: Text }
   | ReplyConsensus Int
 
 renderAnswer :: ReplyAnswerType -> Text
@@ -81,6 +82,11 @@ renderAnswer = \case
       [ "User "
       , userInfoLink u
       , " has been successfully unbanned."
+      ]
+  ReplyUnknownUsername txt ->
+    Text.concat
+      [ "User ", txt, " could not be identified due to Telegram limitations. "
+      , "Try to obtain id via @getInfoByIdBot"
       ]
 
 selfDestructReply :: WithBotState => ChatId -> ChatState -> ReplyAnswerType -> BotM ()

--- a/src/Watcher/Bot/State.hs
+++ b/src/Watcher/Bot/State.hs
@@ -17,6 +17,7 @@ import Katip
 import Servant.Client (ClientEnv, ClientM, runClientM)
 import System.IO (stdout)
 import Telegram.Bot.API
+import Telegram.Bot.API.Names
 
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
@@ -132,7 +133,10 @@ alterBlocklist
 alterBlocklist cache UserInfo{..} modifier =
   let modifyUsername x = case userInfoUsername of
         Nothing -> x
-        Just username -> HM.insert username userInfoId x
+        Just username ->
+          let normalUsername = normaliseUsername username
+              insertUsername u = HM.insert u userInfoId x
+          in maybe x insertUsername normalUsername
       alter b@Blocklist{..} = b
         { spamerBans = HM.alter modifier userInfoId spamerBans
         , spamerUsernames = modifyUsername spamerUsernames


### PR DESCRIPTION
In previous I forgot to add actual lookup for userId via username in unban process. This MR fixes it.