### PR TITLE
In case of ban remove all spammer's messages

### DIFF
--- a/config/migrations/05-track-message-ids-in-quarantine.dhall
+++ b/config/migrations/05-track-message-ids-in-quarantine.dhall
@@ -1,0 +1,134 @@
+-- * common
+
+let Prelude = ../common/map.dhall
+let Entry = Prelude.Entry
+let Map = Prelude.Map
+let map = Prelude.map
+
+let UTCTime = { date : Date, time : Time, timeZone : TimeZone }
+
+-- * previous
+
+let PrevChatSettings =
+      { messagesInQuarantine : Integer
+      , spamCommandAction : < SCAdminsCall | SCPoll >
+      , usersForConsensus : Integer
+      , selfDestroyEnabled : Bool
+      }
+
+let PrevChatSetupState =
+      < SetupCompleted :
+          { setupCompletedAt : UTCTime
+          , setupCompletedByAdmin : Integer
+          }
+      | SetupInProgress :
+          { setupModifiedAt : UTCTime
+          , setupModifiedByAdmin : Integer
+          }
+      | SetupNone
+      >
+
+let PrevUserInfo =
+      { userInfoId : Integer
+      , userInfoFirstName : Text
+      , userInfoLastName : Optional Text
+      , userInfoUsername : Optional Text
+      , userInfoLink : Text
+      }
+
+
+let PrevChatInfo =
+      { chatInfoId : Integer
+      , chatInfoName : Text
+      , chatInfoTitle : Optional Text
+      , chatInfoBio : Optional Text
+      , chatInfoEmojiStatusCustomEmojiId : Optional Text
+      , chatInfoBackgroundCustomEmojiId : Optional Text
+      }
+
+let PrevMessageInfo =
+      { messageInfoId : Integer
+      , messageInfoThreadId : Optional Integer
+      , messageInfoText : Optional Text
+      , messageInfoFrom : Optional PrevUserInfo
+      , messageInfoChat : PrevChatInfo
+      }
+
+let PrevQuarantine =
+      { _1 : Optional PrevChatInfo
+      , _2 : List Bytes
+      }
+
+let PrevAdminCall =
+      { _1 : PrevUserInfo
+      , _2 : PrevMessageInfo
+      }
+
+let PrevPoll =
+      { pollMessageId : Integer
+      , pollSpamMessageId : Integer
+      , pollVoters : List Integer
+      , pollSpamer : PrevUserInfo
+      }
+
+
+let PrevChatState =
+      { chatSettings : PrevChatSettings
+      , chatAdmins : List Integer
+      , chatAdminsCheckedAt : Optional Date
+      , chatSetup : PrevChatSetupState
+      , quarantine : Map Integer PrevQuarantine
+      , activePolls : Map Integer PrevPoll
+      , adminCalls : Map Integer PrevAdminCall
+      , allowlist : List Integer
+      , botIsAdmin : Bool
+      }
+
+-- * new
+
+let Quarantine =
+      { quarantineUserChatInfo : Optional PrevChatInfo
+      , quarantineMessageHash : List Bytes
+      , quarantineMessageId : List Integer
+      }
+
+let ChatState =
+      { chatSettings : PrevChatSettings
+      , chatAdmins : List Integer
+      , chatAdminsCheckedAt : Optional Date
+      , chatSetup : PrevChatSetupState
+      , quarantine : Map Integer Quarantine
+      , activePolls : Map Integer PrevPoll
+      , adminCalls : Map Integer PrevAdminCall
+      , allowlist : List Integer
+      , botIsAdmin : Bool
+      }
+
+-- * migrate
+
+let migrateQuarantine
+  = λ(old: Entry Integer PrevQuarantine)
+  → { mapKey = old.mapKey
+    , mapValue =
+        { quarantineUserChatInfo = old.mapValue._1
+        , quarantineMessageHash = old.mapValue._2
+        , quarantineMessageId = [] : List Integer
+        }
+    }
+
+let migrateChatState
+  = λ(old: PrevChatState)
+  → old ⫽ { quarantine = map
+              (Entry Integer PrevQuarantine) (Entry Integer Quarantine)
+              migrateQuarantine old.quarantine
+          }
+
+let migrateGroups
+  = λ(old: Entry Integer PrevChatState)
+  → { mapKey = old.mapKey
+    , mapValue = migrateChatState old.mapValue
+    }
+
+in { migrateGroups =
+       map (Entry Integer PrevChatState) (Entry Integer ChatState) migrateGroups
+   }

--- a/src/Watcher/Bot/Handle/Debug.hs
+++ b/src/Watcher/Bot/Handle/Debug.hs
@@ -121,7 +121,7 @@ handleGetChatMember chatId = do
       case HM.toList quarantine of
         [] -> reply "No users in quarantine"
         xs -> do
-          texts <- forM xs $ \(userId, (_mChatInfo, messageHashes)) -> do
+          texts <- forM xs $ \(userId, QuarantineState{..}) -> do
             mResponse <- call $ getChatMember (SomeChatId chatId) userId
             let responseToText x =
                   let cm = responseResult x
@@ -132,7 +132,7 @@ handleGetChatMember chatId = do
                 userStatus = Text.concat
                   [ s2t (coerce @_ @Integer userId)
                   , ": ", responseText
-                  , ", ", s2t (length messageHashes)
+                  , ", ", s2t (length quarantineMessageHash)
                   ]
             pure userStatus
           let fullChatResponse = Text.concat

--- a/src/Watcher/Bot/State/Chat.hs
+++ b/src/Watcher/Bot/State/Chat.hs
@@ -22,7 +22,7 @@ data ChatState = ChatState
   , chatAdmins :: HashSet UserId
   , chatAdminsCheckedAt :: Maybe Day
   , chatSetup :: SetupState
-  , quarantine :: HashMap UserId (Maybe ChatInfo, Set MessageHash)
+  , quarantine :: HashMap UserId QuarantineState
   , activePolls :: HashMap SpamerId PollState -- ^ key is candidate for ban in given group, value is a set of unique voters in favour of ban and a message with poll.
   , adminCalls :: HashMap SpamerId (UserInfo, MessageInfo)
   , allowlist :: HashSet UserId
@@ -122,3 +122,17 @@ data PollState = PollState
   , pollSpamMessageId :: MessageId
   }
   deriving (Show, Eq, Generic, FromDhall, ToDhall)
+
+data QuarantineState = QuarantineState
+  { quarantineUserChatInfo :: Maybe ChatInfo
+  , quarantineMessageHash :: Set MessageHash
+  , quarantineMessageId :: Set MessageId
+  }
+  deriving (Show, Eq, Generic, FromDhall, ToDhall)
+
+emptyQuarantineState :: QuarantineState
+emptyQuarantineState = QuarantineState
+  { quarantineUserChatInfo = Nothing
+  , quarantineMessageHash = mempty
+  , quarantineMessageId = mempty
+  }

--- a/src/Watcher/Orphans.hs
+++ b/src/Watcher/Orphans.hs
@@ -53,6 +53,8 @@ instance FromDhall v => FromDhall (KeyMap v) where
 instance ToDhall v => ToDhall (KeyMap v) where
   injectWith opts = contramap KeyMap.toHashMapText (injectWith opts)
 
+deriving newtype instance Ord MessageId
+
 deriving newtype instance FromDhall MessageId
 
 deriving newtype instance ToDhall MessageId


### PR DESCRIPTION
- Track message identifiers while user is in quarantine. In case of ban events, all of them should be removed too.