### PR TITLE
Add integration with CAS

### DIFF
--- a/config/default.dhall
+++ b/config/default.dhall
@@ -130,4 +130,8 @@ Extra commands:
         , workerPeriodUnits = 4
         }
     }
+, cas =
+    { casEndpoint = "https://api.cas.chat/check?user_id="
+    , casTimeoutMs = 200
+    }
 }

--- a/src/Watcher/Bot/Integration/CAS.hs
+++ b/src/Watcher/Bot/Integration/CAS.hs
@@ -1,0 +1,39 @@
+module Watcher.Bot.Integration.CAS where
+
+import Data.Aeson
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import GHC.Generics (Generic)
+import Network.HTTP.Client
+import Network.HTTP.Client.TLS
+import Telegram.Bot.API.Internal.Utils
+import Telegram.Bot.API.Types.Common
+
+import Watcher.Bot.Settings
+
+newCasClient :: IO Manager
+newCasClient = newManager tlsManagerSettings
+
+data CasResponse = CasResponse
+  { casResponseOk :: Bool
+  , casResponseResult :: Maybe CasResult
+  , casResponseDescription :: Maybe Text
+  }
+  deriving (Generic, Show)
+
+instance FromJSON CasResponse where parseJSON = gparseJSON
+
+data CasResult = CasResult
+  { casResultOffenses :: Maybe Int
+  , casResultMessages :: [Text]
+  , casResultTimeAdded :: Maybe UTCTime
+  }
+  deriving (Generic, Show)
+
+instance FromJSON CasResult where parseJSON = gparseJSON
+
+checkUser :: Manager -> CasSettings -> UserId -> IO (Either String CasResponse)
+checkUser manager CasSettings{..} (UserId userId) = do
+  let request = parseRequest_ $ casEndpoint <> show userId
+  response <- httpLbs request manager
+  pure $ eitherDecode' @CasResponse $ responseBody response

--- a/src/Watcher/Bot/Reply.hs
+++ b/src/Watcher/Bot/Reply.hs
@@ -39,6 +39,7 @@ data ReplyAnswerType
   | ReplyUserHasNotBeenBanned { replyUserHasNotBeenBanned :: UserInfo }
   | ReplyUserHasBeenUnbanned { replyUserHasBeenUnbanned :: UserInfo }
   | ReplyUserAlreadyBanned { replyUserAlreadyBanned :: UserInfo }
+  | ReplyUserCASBanned { replyUserCASBanned :: UserInfo }
   | ReplyUserRecovered { replyUserRecovered :: UserInfo }
   | ReplyUnknownUsername { replyUnknownUsername :: Text }
   | ReplyConsensus Int
@@ -58,6 +59,12 @@ renderAnswer = \case
       [ "User "
       , userInfoLink u
       , " has been recognised as a known spammer and been removed from the group."
+      ]
+  ReplyUserCASBanned u ->
+    Text.concat
+      [ "User "
+      , userInfoLink u
+      , " has been CAS banned."
       ]
   ReplyUserRecovered u ->
     Text.concat

--- a/src/Watcher/Bot/Settings.hs
+++ b/src/Watcher/Bot/Settings.hs
@@ -70,6 +70,11 @@ data AnalyticsSettings = AnalyticsSettings
   , restEventsPath :: FilePath
   } deriving (Generic, FromDhall, ToDhall, Show)
 
+data CasSettings = CasSettings
+  { casEndpoint :: String
+  , casTimeoutMs :: Natural
+  } deriving (Generic, FromDhall, ToDhall, Show)
+
 data Settings = Settings
   { botName :: Text -- ^ Telegram bot name. Used to parse @/command\@botname@.
   , botToken :: Text -- ^ Bot token.
@@ -81,6 +86,7 @@ data Settings = Settings
   , storage :: StorageSettings
   , analytics :: AnalyticsSettings
   , workers :: WorkersSettings
+  , cas :: CasSettings
   } deriving (Generic, FromDhall, ToDhall, Show)
 
 data WorkersSettings = WorkersSettings

--- a/watcher-bot.cabal
+++ b/watcher-bot.cabal
@@ -72,6 +72,7 @@ library
                       Watcher.Bot.Handle.Message
                       Watcher.Bot.Handle.Setup
                       Watcher.Bot.Handle.Unban
+                      Watcher.Bot.Integration.CAS
                       Watcher.Bot.ModelChecker
                       Watcher.Bot.Parse
                       Watcher.Bot.Reply
@@ -119,6 +120,8 @@ library
                     , exceptions
                     , filepath
                     , hashable
+                    , http-client
+                    , http-client-tls
                     , katip
                     , mtl
                     , optparse-applicative


### PR DESCRIPTION
- Settings with endpoint and timeout (which is not in use yet)
- Inject integration call:
    - on join event (new chat member)
    - on message in quarantine
    - inside background chat members check
- Examples:

```
curl -X GET 'https://api.cas.chat/check?user_id=7596325892'
{"ok":true,"result":{"offenses":1,"messages":["Reward Vault:\n✔️ Single reward of 100 USDT\n✔️ Pair of 50 USDT rewards\n✔️ Trio of 30 USDT rewards \n✔️ Deca rewards of 10 USDT each\n\nTap the given link for your chance to snatch up these giveaways without spending a dim"],"time_added":"2024-12-16T10:14:01.000Z"}}
```

```
curl -X GET 'https://api.cas.chat/check?user_id=25650'
{"ok":false,"description":"Record not found."}
```