### PR TITLE
Disable background CAS checks

### DIFF
--- a/src/Watcher/Bot/Handle/ChatMember.hs
+++ b/src/Watcher/Bot/Handle/ChatMember.hs
@@ -2,7 +2,6 @@ module Watcher.Bot.Handle.ChatMember where
 
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO)
-import Data.Maybe (isJust)
 import Data.Text (Text)
 import Telegram.Bot.API
 
@@ -16,12 +15,10 @@ handleCheckChatMember
 handleCheckChatMember chatId user = do
   let userId = toUserId user
   mResponse <- call $ getChatMember (SomeChatId chatId) userId
-  mMessages <- callCasCheck userId
 
   let status = maybe "unknown" (chatMemberStatus . responseResult) mResponse :: Text
-  when (status == "kicked" || isJust mMessages) $ do
-    let texts = maybe [] (fmap MessageText) mMessages
-    updateBlocklist chatId (toUserInfo user) texts
+  when (status == "kicked") $ do
+    updateBlocklist chatId (toUserInfo user) []
     endQuarantineForUser chatId userId
 
   pure status


### PR DESCRIPTION
Bot is being rate-limited with following messages:

```
[2024-12-27 10:43:22][Watcher][Info][build-server][PID 1453324][ThreadId 16] "Unexpected \"<!DOCTYPE html><html lang=\\\"en-\", expecting JSON value"
[2024-12-27 10:56:14][Watcher][Info][build-server][PID 1453324][ThreadId 16] "Unexpected \"<!DOCTYPE html><html lang=\\\"en-\", expecting JSON value"
[2024-12-27 10:58:11][Watcher][Info][build-server][PID 1453324][ThreadId 16] "Unexpected \"<!DOCTYPE html><html lang=\\\"en-\", expecting JSON value"
[2024-12-27 11:01:46][Watcher][Info][build-server][PID 1453324][ThreadId 16] "Unexpected \"<!DOCTYPE html><html lang=\\\"en-\", expecting JSON value"
[2024-12-27 11:04:50][Watcher][Info][build-server][PID 1453324][ThreadId 16] "Unexpected \"<!DOCTYPE html><html lang=\\\"en-\", expecting JSON value"
[2024-12-27 11:08:10][Watcher][Info][build-server][PID 1453324][ThreadId 16] "Unexpected \"<!DOCTYPE html><html lang=\\\"en-\", expecting JSON value"
[2024-12-27 11:14:52][Watcher][Info][build-server][PID 1453324][ThreadId 16] "Unexpected \"<!DOCTYPE html><html lang=\\\"en-\", expecting JSON value"
[2024-12-27 11:15:58][Watcher][Info][build-server][PID 1453324][ThreadId 16] "Unexpected \"<!DOCTYPE html><html lang=\\\"en-\", expecting JSON value"
[2024-12-27 11:23:38][Watcher][Info][build-server][PID 1453324][ThreadId 16] "Unexpected \"<!DOCTYPE html><html lang=\\\"en-\", expecting JSON value"
```

Hundreds of them. It seems that bot is being rate-limited. The quickest win is to disable background checks.