### PR TITLE
CSV Parser for `Event` + keep 5 days of cache

### DIFF
--- a/src/Watcher/Bot/Analytics.hs
+++ b/src/Watcher/Bot/Analytics.hs
@@ -1,7 +1,8 @@
 module Watcher.Bot.Analytics where
 
+import Control.Monad (mzero)
 import Control.Monad.IO.Class (liftIO)
-import Data.Csv (ToRecord (..), ToField (..))
+import Data.Csv (FromRecord (..), FromField (..), ToRecord (..), ToField (..))
 import Data.Text (Text)
 import Data.Time (UTCTime (..))
 import Dhall (FromDhall (..), ToDhall (..))
@@ -31,6 +32,21 @@ data EventType
   | EventUserPrivateCommand
   deriving (Eq, Show, Ord, Generic, FromDhall, ToDhall)
 
+instance FromField EventType where
+  parseField = \case
+    "group_add" -> pure EventGroupAdd
+    "group_setup" -> pure EventGroupSetup
+    "group_setup_completed" -> pure EventGroupSetupCompleted
+    "user_setup" -> pure EventUserSetup
+    "spam" -> pure EventGroupSpam
+    "probably_spam_recognised" -> pure EventGroupRecogniseProbablySpam
+    "most_likely_spam_recognised" -> pure EventGroupRecogniseMostLikelySpam
+    "ban" -> pure EventGroupBan
+    "unban" -> pure EventGroupUnban
+    "leave_unsupported" -> pure EventLeaveUnsupported
+    "private_command" -> pure EventUserPrivateCommand
+    _ -> mzero
+
 instance ToField EventType where
   toField = \case
     EventGroupAdd -> "group_add"
@@ -51,7 +67,7 @@ data Event = Event
   , eventChatId :: Maybe ChatId
   , eventUserId :: Maybe UserId
   , eventData :: Maybe Text
-  } deriving (Eq, Generic, ToRecord)
+  } deriving (Show, Eq, Generic, ToRecord, FromRecord)
 
 event :: UTCTime -> EventType -> Event
 event time evtType = Event time evtType Nothing Nothing Nothing

--- a/src/Watcher/Bot/Cache.hs
+++ b/src/Watcher/Bot/Cache.hs
@@ -89,7 +89,8 @@ cleanCache dir = do
       let fullPath = "." </> "cache" </> dayDir </> dir </> file
       filesize <- getFileSize fullPath
       when (filesize > 0) $ do
-        days <- filter (/= dayDir) <$> listDirectory "cache"
+        -- keep last five days of cache
+        days <- drop 5 . sortOn Down <$> listDirectory "cache"
         let makeCacheDir d = "cache" </> d </> dir
         forM_ days $ \day -> removeDirectoryIfExist (makeCacheDir day)
 

--- a/src/Watcher/Bot/Handle/Ban.hs
+++ b/src/Watcher/Bot/Handle/Ban.hs
@@ -73,7 +73,7 @@ handleAdminBan chatId ch@ChatState{..} userId messageId adminBanId = do
 banSpamerInChat :: WithBotState => ChatId -> UserInfo -> BotM ()
 banSpamerInChat chatId spamer = do
   now <- liftIO getCurrentTime
-  sendEvent (chatEvent now chatId EventGroupBan)
+  sendEvent ((chatEvent now chatId EventGroupBan) { eventUserId = Just $ userInfoId spamer })
 
   let banReq = (defBanChatMember (SomeChatId chatId) (userInfoId spamer))
         { banChatMemberRevokeMessages = Just True }

--- a/src/Watcher/Bot/State.hs
+++ b/src/Watcher/Bot/State.hs
@@ -106,6 +106,12 @@ data BanState = BanState
   , bannedChats :: HashSet ChatId
   } deriving (Eq, Show, Generic, FromDhall, ToDhall)
 
+instance Semigroup BanState where
+  a <> b = BanState
+    { bannedMessages = HS.union (bannedMessages a) (bannedMessages b)
+    , bannedChats = HS.union (bannedChats a) (bannedChats b)
+    }
+
 newBanState :: BanState
 newBanState = BanState
   { bannedMessages = HS.empty

--- a/src/Watcher/Orphans.hs
+++ b/src/Watcher/Orphans.hs
@@ -7,11 +7,11 @@
 module Watcher.Orphans where
 
 import Data.Aeson.KeyMap (KeyMap)
-import Data.Csv (ToField (..))
+import Data.Csv (ToField (..), FromField (..))
 import Data.Functor.Contravariant (contramap)
 import Data.Hashable (Hashable)
 import Data.Time
-import Data.Time.Format.ISO8601 (iso8601Show)
+import Data.Time.Format.ISO8601 (iso8601ParseM, iso8601Show)
 import Data.Time.Clock.POSIX
 import Dhall.Marshal.Decode (FromDhall (..), double, hashMap, strictText)
 import Dhall.Marshal.Encode (Encoder (..), ToDhall (..))
@@ -25,6 +25,8 @@ import qualified Dhall.Core as Core
 deriving newtype instance FromDhall ChatId
 
 deriving newtype instance ToDhall ChatId
+
+deriving newtype instance FromField ChatId
 
 deriving newtype instance ToField ChatId
 
@@ -90,6 +92,8 @@ deriving newtype instance FromDhall UserId
 
 deriving newtype instance ToDhall UserId
 
+deriving newtype instance FromField UserId
+
 deriving newtype instance ToField UserId
 
 deriving instance Eq ChatType
@@ -100,3 +104,6 @@ deriving instance Generic UserId
 
 instance ToField UTCTime where
   toField = BS8.pack . iso8601Show
+
+instance FromField UTCTime where
+  parseField = iso8601ParseM . BS8.unpack


### PR DESCRIPTION
All data has been restored via repl, logged events and pyrogram-based chat export. Few improvements captured in code:

- CSV parser for Event type and its fields.
- Keep 5 days of cache instead of a single one.