### PR TITLE
Nightly backups + scheduled workers + debug in owner's group

### DIFF
--- a/config/default.dhall
+++ b/config/default.dhall
@@ -6,6 +6,7 @@ let OwnerGroup =
       , ownerGroupTuningThreadId : Integer
       , ownerGroupFeedbackThreadId : Integer
       , ownerGroupStatsThreadId : Integer
+      , ownerGroupBackupThreadId : Integer
       }
 let SpamCommandAction = < SCPoll | SCAdminsCall >
 let ScoreSettings =
@@ -44,6 +45,10 @@ let _adminHelp =
   *Tip*: you can include your feedback right after the command in that same message\.
     ''
 let WorkerPeriod = < Second | Minute | Hour | Day | Week >
+let WorkerMode =
+  < WorkerRange : { workerRangeFrom : Time, workerRangeTo : Time }
+  | WorkerAt : { workerAt : Time }
+  >
 in
 { botName = env:WATCHER_BOT_NAME as Text
 , botToken = env:WATCHER_BOT_TOKEN as Text
@@ -53,6 +58,7 @@ in
          , ownerGroupTuningThreadId = +4
          , ownerGroupFeedbackThreadId = +3
          , ownerGroupStatsThreadId = +5
+         , ownerGroupBackupThreadId = +1626
          } 
 , debugEnabled = False
 , defaultGroupSettings =
@@ -106,6 +112,7 @@ Extra commands:
     , blocklistPath = "blocklist"
     , spamMessagesPath = "spam_messages"
     , eventSetPath = "triggered_events"
+    , archiveDir = "backups"
     }
 , analytics =
     { analyticsDir = "./bigdata"
@@ -118,16 +125,22 @@ Extra commands:
         { workerName = "cleanup"
         , workerPeriod = WorkerPeriod.Day
         , workerPeriodUnits = 1
+        , workerMode = Some (WorkerMode.WorkerAt { workerAt = 01:00:00 })
         }
     , dump =
         { workerName = "dump"
         , workerPeriod = WorkerPeriod.Hour
         , workerPeriodUnits = 2
+        , workerMode = None WorkerMode
         }
     , statistics =
         { workerName = "statistics"
         , workerPeriod = WorkerPeriod.Hour
         , workerPeriodUnits = 4
+        , workerMode = Some (WorkerMode.WorkerRange
+            { workerRangeFrom = 07:00:00
+            , workerRangeTo = 23:59:59
+            })
         }
     }
 , cas =

--- a/src/Watcher/Bot/Parse.hs
+++ b/src/Watcher/Bot/Parse.hs
@@ -231,7 +231,7 @@ handleMessage settings@Settings{..} upd@Update{..}
             then if isJust $ messageReplyToMessage msg
               then Just $! ContactUser msg
               else Nothing
-            else Nothing
+            else Just $! Debug upd
         DirectMessage userId  -> Just $! CheckUserContactState userId msg
         PublicGroup chatId userId -> if debugEnabled
           then Just $! Debug upd

--- a/src/Watcher/Bot/Settings.hs
+++ b/src/Watcher/Bot/Settings.hs
@@ -6,6 +6,7 @@
 module Watcher.Bot.Settings where
 
 import Data.Map.Strict (Map)
+import Data.Time (TimeOfDay)
 import Dhall
 
 data SpamCommand
@@ -31,6 +32,7 @@ data OwnerGroupSettings = OwnerGroupSettings
   , ownerGroupTuningThreadId :: Integer -- ^ MessageThreadId of tuning topic.
   , ownerGroupFeedbackThreadId :: Integer -- ^ MessageThreadId of feedback topic.
   , ownerGroupStatsThreadId :: Integer -- ^ MessageThreadId of statistics topic.
+  , ownerGroupBackupThreadId :: Integer -- ^ MessageThreadId of topics for backups.
   } deriving (Generic, FromDhall, ToDhall, Show)
 
 data ScoreSettings = ScoreSettings
@@ -61,6 +63,7 @@ data StorageSettings = StorageSettings
   , blocklistPath :: FilePath
   , spamMessagesPath :: FilePath
   , eventSetPath :: FilePath
+  , archiveDir :: FilePath
   } deriving (Generic, FromDhall, ToDhall, Show)
 
 data AnalyticsSettings = AnalyticsSettings
@@ -99,6 +102,7 @@ data WorkerSettings = WorkerSettings
   { workerName :: Text
   , workerPeriod :: WorkerPeriod
   , workerPeriodUnits :: Natural
+  , workerMode :: Maybe WorkerMode
   } deriving (Generic, FromDhall, ToDhall, Show)
 
 data WorkerPeriod = Second | Minute | Hour | Day | Week
@@ -111,6 +115,11 @@ workerPeriodToSec = \case
   Hour -> 60 * 60
   Day -> 60 * 60 * 24
   Week -> 60 * 60 * 24 * 7
+
+data WorkerMode
+  = WorkerRange { workerRangeFrom :: TimeOfDay, workerRangeTo :: TimeOfDay }
+  | WorkerAt { workerAt :: TimeOfDay }
+  deriving (Generic, FromDhall, ToDhall, Show)
 
 -- | Load settings from file.
 loadSettings :: Text -> IO Settings

--- a/src/Watcher/Bot/Worker.hs
+++ b/src/Watcher/Bot/Worker.hs
@@ -1,0 +1,36 @@
+module Watcher.Bot.Worker where
+
+import Control.Monad (forever, forM_, unless)
+import GHC.Stack (HasCallStack)
+import Data.Time
+  (LocalTime (..), daysAndTimeOfDayToTime, getCurrentTime, utc, utcToLocalTime)
+
+import Watcher.Bot.Settings
+import Watcher.Bot.State
+import Watcher.Bot.Utils
+
+every :: WithBotState => HasCallStack => WorkerSettings -> IO () -> IO ()
+every WorkerSettings{..} action = do
+  logT $ "Start worker: " <> workerName
+  forever $ do
+    now <- getCurrentTime
+    let todToSec = daysAndTimeOfDayToTime 0
+        todNow = localTimeOfDay (utcToLocalTime utc now)
+        getDelta a b = if a <= b
+          then todToSec b - todToSec a
+          else 86400 - (todToSec a - todToSec b)
+    forM_ workerMode \case
+      WorkerRange{..} -> do
+        let delta = getDelta todNow workerRangeFrom
+        unless (workerRangeFrom <= todNow && todNow <= workerRangeTo) do
+          logT $ "Too early: " <> workerName <> " is waiting... " <> s2t delta <> " seconds"
+          wait (round delta)
+
+      WorkerAt{..} -> do
+        let delta = getDelta todNow workerAt
+        logT $ "Too early: " <> workerName <> " is waiting... " <> s2t delta <> " seconds"
+        wait (round delta)
+
+    logT $ "Run worker: " <> workerName
+    action
+    wait (fromIntegral workerPeriodUnits * workerPeriodToSec workerPeriod)

--- a/watcher-bot.cabal
+++ b/watcher-bot.cabal
@@ -89,6 +89,7 @@ library
                       Watcher.Bot.Types.MessageFrom
                       Watcher.Bot.Types.UserInfo
                       Watcher.Bot.Utils
+                      Watcher.Bot.Worker
                       Watcher.Migration
                       Watcher.Orphans
                       Telegram.Bot.API.Names
@@ -129,12 +130,14 @@ library
                     , safe-exceptions
                     , servant-client
                     , stm
+                    , tar
                     , telegram-bot-api  >= 7.4.4
                     , telegram-bot-simple >= 0.14.3
                     , text
                     , time
                     , unordered-containers
                     , vector
+                    , zstd
 
     -- Directories containing source files.
     hs-source-dirs:   src


### PR DESCRIPTION
- Extend cleanup job with backup capability: create TAR, compress it with `zstd` and publish to `#backups` topic.
- Extend `every` worker with one of two worker modes: time range during the day (right now only one range has supported) and bound to a specific time of day.
- Restore debug for owners group.