### PR TITLE
feat: analyse message of incoming users and try to ban them

### DIFF
--- a/config/dictionary.dhall
+++ b/config/dictionary.dhall
@@ -62,5 +62,7 @@
 , { mapKey = "bybit", mapValue = 400 }
 , { mapKey = "usd", mapValue = 300 }
 , { mapKey = "eur", mapValue = 300 }
+, { mapKey = "детское", mapValue = 100 }
 , { mapKey = "доллар", mapValue = 300 }
+, { mapKey = "порно", mapValue = 1000 }
 ]


### PR DESCRIPTION
- A new spammer trend appears. 
- They provoke captcha bot to show their names and leave the group to prevent them being banned
- This PR handles checking of user names (not usernames) on chat_join event.