### PR TITLE
Draft: switch bot to webhook communication mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist-newstyle
 config/settings.dhall
+self-signed

--- a/config/default.dhall
+++ b/config/default.dhall
@@ -60,6 +60,7 @@ let WorkerMode =
   >
 in
 { botName = env:WATCHER_BOT_NAME as Text
+, botResponseTimeout = 60
 , botToken = env:WATCHER_BOT_TOKEN as Text
 , ownerGroup =
     Some { ownerGroupId = env:WATCHER_BOT_OWNER_GROUP

--- a/config/default.dhall
+++ b/config/default.dhall
@@ -157,5 +157,10 @@ Extra commands:
     , casEndpoint = "https://api.cas.chat/check?user_id="
     , casTimeoutMs = 200
     }
-, communication = Communication.LongPolling
+, communication = Communication.Webhook
+    { webhookCertPath = env:WATCHER_BOT_CERT_PATH
+    , webhookHost = env:WATCHER_BOT_WEBHOOK_HOST
+    , webhookPort = env:WATCHER_BOT_WEBHOOK_PORT
+    , webhookKeyPath = env:WATCHER_BOT_KEY_PATH
+    }
 }

--- a/config/default.dhall
+++ b/config/default.dhall
@@ -158,9 +158,9 @@ Extra commands:
     , casTimeoutMs = 200
     }
 , communication = Communication.Webhook
-    { webhookCertPath = env:WATCHER_BOT_CERT_PATH
-    , webhookHost = env:WATCHER_BOT_WEBHOOK_HOST
+    { webhookCertPath = env:WATCHER_BOT_CERT_PATH as Text
+    , webhookHost = env:WATCHER_BOT_WEBHOOK_HOST as Text
     , webhookPort = env:WATCHER_BOT_WEBHOOK_PORT
-    , webhookKeyPath = env:WATCHER_BOT_KEY_PATH
+    , webhookKeyPath = env:WATCHER_BOT_KEY_PATH as Text
     }
 }

--- a/config/default.dhall
+++ b/config/default.dhall
@@ -1,5 +1,14 @@
 let Map = https://prelude.dhall-lang.org/Map/Type
 let Map/empty = https://prelude.dhall-lang.org/Map/empty
+let Communication =
+      < LongPolling
+      | Webhook
+        : { webhookCertPath : Text
+          , webhookKeyPath : Text
+          , webhookPort : Natural
+          , webhookHost : Text
+          }
+      >
 let OwnerGroup =
       { ownerGroupId : Integer
       , ownerGroupSpamThreadId : Integer
@@ -148,4 +157,5 @@ Extra commands:
     , casEndpoint = "https://api.cas.chat/check?user_id="
     , casTimeoutMs = 200
     }
+, communication = Communication.LongPolling
 }

--- a/scripts/gen-self-signed-cert.sh
+++ b/scripts/gen-self-signed-cert.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eux
+cwd=`pwd`
+trap "cd ${cwd}" EXIT
+
+mkdir self-signed
+cd self-signed
+openssl genrsa -out key.pem 4096
+openssl req -new -key key.pem  -out certificate.csr
+openssl x509 -req -in certificate.csr -signkey key.pem -out certificate.pem

--- a/src/Watcher/Bot/Settings.hs
+++ b/src/Watcher/Bot/Settings.hs
@@ -93,6 +93,7 @@ data CasSettings = CasSettings
 
 data Settings = Settings
   { botName :: Text -- ^ Telegram bot name. Used to parse @/command\@botname@.
+  , botResponseTimeout :: Natural -- ^ Response timeout for API requests in seconds.
   , botToken :: Text -- ^ Bot token.
   , ownerGroup :: Maybe OwnerGroupSettings -- ^ Optional, super-admin group settings.
   , debugEnabled :: Bool -- ^ Whether debug enabled or not

--- a/src/Watcher/Bot/Settings.hs
+++ b/src/Watcher/Bot/Settings.hs
@@ -9,6 +9,18 @@ import Data.Map.Strict (Map)
 import Data.Time (TimeOfDay)
 import Dhall
 
+data WebhookSettings = WebhookSettings
+  { webhookCertPath :: FilePath
+  , webhookKeyPath :: FilePath
+  , webhookPort :: Natural
+  , webhookHost :: Text
+  } deriving (Eq, Show, Read, Generic, FromDhall, ToDhall)
+
+data Communication
+  = LongPolling
+  | Webhook WebhookSettings
+  deriving (Eq, Show, Read, Generic, FromDhall, ToDhall)
+
 data SpamCommand
   = SCPoll
   | SCAdminsCall
@@ -91,6 +103,7 @@ data Settings = Settings
   , analytics :: AnalyticsSettings
   , workers :: WorkersSettings
   , cas :: CasSettings
+  , communication :: Communication
   } deriving (Generic, FromDhall, ToDhall, Show)
 
 data WorkersSettings = WorkersSettings

--- a/watcher-bot.cabal
+++ b/watcher-bot.cabal
@@ -137,6 +137,8 @@ library
                     , time
                     , unordered-containers
                     , vector
+                    , warp
+                    , warp-tls
                     , zstd
 
     -- Directories containing source files.


### PR DESCRIPTION
- [X] Add Webhook mode to the bot
- [X] Add switch between `Webhook` and `LongPolling`.
- [x] Set up webhook on server (either document or create dhall config to reduce amount of human actions).
- [x] Ensure bot is capable of receiving updates from Telegram.
- [x] Enable webhook by default.