### PR TITLE
Make retries configurable

### DIFF
--- a/config/default.dhall
+++ b/config/default.dhall
@@ -60,7 +60,8 @@ let WorkerMode =
   >
 in
 { botName = env:WATCHER_BOT_NAME as Text
-, botResponseTimeout = 60
+, botResponseTimeout = 20
+, botCallRetries = 30
 , botToken = env:WATCHER_BOT_TOKEN as Text
 , ownerGroup =
     Some { ownerGroupId = env:WATCHER_BOT_OWNER_GROUP

--- a/src/Watcher/Bot/Settings.hs
+++ b/src/Watcher/Bot/Settings.hs
@@ -94,6 +94,7 @@ data CasSettings = CasSettings
 data Settings = Settings
   { botName :: Text -- ^ Telegram bot name. Used to parse @/command\@botname@.
   , botResponseTimeout :: Natural -- ^ Response timeout for API requests in seconds.
+  , botCallRetries :: Natural -- ^ Amount of retries
   , botToken :: Text -- ^ Bot token.
   , ownerGroup :: Maybe OwnerGroupSettings -- ^ Optional, super-admin group settings.
   , debugEnabled :: Bool -- ^ Whether debug enabled or not


### PR DESCRIPTION
- Also rename `withLock` to `withLockAndRetry` 
- and wrap interaction with `requestLock` in its own `withLock` isolated helper.