### PR TITLE
Do not discard new quarantine state for newcomers

### DIFF
--- a/src/Watcher/Bot/Handle/Message.hs
+++ b/src/Watcher/Bot/Handle/Message.hs
@@ -13,7 +13,6 @@ import Data.Text (Text)
 import Data.Time (addUTCTime, getCurrentTime)
 import Dhall (Natural)
 import Telegram.Bot.API
-import Telegram.Bot.API.Types.TextQuote (TextQuote(..))
 import Telegram.Bot.API.Names
 import Telegram.Bot.Simple
 
@@ -203,9 +202,8 @@ addToQuarantineOrBan chatId ch@ChatState{..} message newcomers = do
 
   let toQuarantineEntry (mChat, User{..}) =
         (userId, emptyQuarantineState { quarantineUserChatInfo = mChat })
-      go prev _new = prev -- current strategy: leave previous state, do not flush it
   newUserMap <- liftIO $ HT.fromList (toQuarantineEntry <$> catMaybes newcomersWithChats)
-  nextQuarantine <- liftIO $ HT.unionWith go chatStateQuarantine newUserMap
+  nextQuarantine <- liftIO $ HT.unionWith (<>) chatStateQuarantine newUserMap
   let nextState = ch { chatStateQuarantine = nextQuarantine }
 
   writeCache groups chatId nextState

--- a/src/Watcher/Bot/State/Chat.hs
+++ b/src/Watcher/Bot/State/Chat.hs
@@ -1,5 +1,6 @@
 module Watcher.Bot.State.Chat where
 
+import Control.Applicative ((<|>))
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Set (Set)
 import Data.Text (Text)
@@ -183,3 +184,13 @@ emptyQuarantineState = QuarantineState
   , quarantineMessageHash = mempty
   , quarantineMessageId = mempty
   }
+
+instance Monoid QuarantineState where
+  mempty = emptyQuarantineState
+
+instance Semigroup QuarantineState where
+  a <> b = QuarantineState
+    { quarantineUserChatInfo = quarantineUserChatInfo a <|> quarantineUserChatInfo b
+    , quarantineMessageHash = quarantineMessageHash a <> quarantineMessageHash b
+    , quarantineMessageId = quarantineMessageId a <> quarantineMessageId b
+    }


### PR DESCRIPTION
It seems, since the migration to hashtables quarantines became partially broken. This PR should fix this by properly merging two quarantines for the same user