### PR TITLE
Pass more info about ban caller into Ban API

### DIFF
--- a/src/Watcher/Bot/Handle/Ban.hs
+++ b/src/Watcher/Bot/Handle/Ban.hs
@@ -1,11 +1,9 @@
 module Watcher.Bot.Handle.Ban where
 
-import Control.Applicative ((<|>))
-import Control.Concurrent.STM (readTVarIO)
 import Control.Monad (forM_, void, when, unless)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Coerce (coerce)
-import Data.Maybe (fromMaybe, isJust, isNothing)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import Data.Time (getCurrentTime)
 import Telegram.Bot.API
@@ -30,13 +28,17 @@ import Watcher.Bot.Utils
 handleBanAction
   :: WithBotState => ChatId -> ChatState -> VoterId -> MessageId -> MessageInfo -> BotM ()
 handleBanAction chatId ch@ChatState{..} voterId messageId orig = do
+  forwardToOwnersMaybe Spam chatId (messageInfoId orig)
   voterIsAdmin <- liftIO (isJust <$> HT.lookup chatStateAdmins (coerce @_ @UserId voterId))
   if voterIsAdmin
     then handleBanByAdmin chatId ch orig
-    else handleBanByRegularUser chatId ch (Just voterId) orig
+    else do
+      let banReporter = case ((VoterId . userInfoId) <$> messageInfoFrom orig) == Just voterId of
+            True -> BySpamer (coerce voterId)
+            False -> ByUser voterId
+      handleBanByRegularUser chatId ch banReporter orig
   -- remove bot message itself
   void $ call $ deleteMessage chatId messageId
-  forwardToOwnersMaybe Spam chatId (messageInfoId orig)
 
 handleAdminBan
   :: WithBotState
@@ -105,18 +107,23 @@ handleBanByAdmin chatId ch@ChatState{..} orig@MessageInfo{..} = do
     banSpamerInChat chatId spamer
 
 handleBanByRegularUser
-  :: WithBotState => ChatId -> ChatState -> Maybe VoterId -> MessageInfo -> BotM ()
-handleBanByRegularUser chatId ch@ChatState{..} mVoterId orig = do
+  :: WithBotState => ChatId -> ChatState -> BanRequestedBy -> MessageInfo -> BotM ()
+handleBanByRegularUser chatId ch@ChatState{..} banReporter orig = do
   now <- liftIO getCurrentTime
-  let evt = (chatEvent now chatId EventGroupSpam)
-        { eventData = Just "by_user_or_bot" }
+  let evtLog = case banReporter of
+        ByBot _ -> "by_bot"
+        ByAdmin _ -> "by_admin"
+        BySpamer _ -> "by_spamer"
+        ByUser _ -> "by_user"
+      evt = (chatEvent now chatId EventGroupSpam)
+        { eventData = Just evtLog }
   sendEvent evt
 
   let GroupSettings{spamCommandAction, usersForConsensus} = chatStateSettings
       mSpamerUser = messageInfoFrom orig
   forM_ mSpamerUser $ \spamer -> case spamCommandAction of
     SCPoll ->
-      handleBanViaConsensusPoll chatId ch mVoterId spamer orig usersForConsensus
+      handleBanViaConsensusPoll chatId ch banReporter spamer orig usersForConsensus
     SCAdminsCall -> handleBanViaAdminsCall chatId ch spamer orig
 
 handleBanViaAdminsCall
@@ -144,14 +151,13 @@ handleBanViaConsensusPoll
   :: WithBotState
   => ChatId
   -> ChatState
-  -> Maybe VoterId
+  -> BanRequestedBy
   -> UserInfo
   -> MessageInfo
   -> Integer
   -> BotM ()
-handleBanViaConsensusPoll chatId ch@ChatState{..} mVoterId spamer orig consensus = do
-  let BotState {..} = ?model
-      spamerId = SpamerId $! userInfoId spamer
+handleBanViaConsensusPoll chatId ch@ChatState{..} banReporter spamer orig consensus = do
+  let spamerId = SpamerId $! userInfoId spamer
   userAlreadyBanned <- hasUserAlreadyBannedElsewhere (userInfoId spamer)
   if userAlreadyBanned
     then do
@@ -160,30 +166,28 @@ handleBanViaConsensusPoll chatId ch@ChatState{..} mVoterId spamer orig consensus
       removeAllQuarantineMessages ch chatId spamerId
       selfDestructReply chatId ch (ReplyUserAlreadyBanned spamer)
     else do
-      botItself <- liftIO $ readTVarIO self
       adminReported <- liftIO (isJust <$> HT.lookup chatStateAdmins (coerce spamerId))
-      let mBotId = (VoterId . userInfoId) <$> botItself
-          mVoterIdOrBotId = mVoterId <|> mBotId
-          voter = if isNothing mVoterIdOrBotId || isJust mBotId
-            then BotVoter
-            else UserVoter
-          selfReport = maybe False (coerce spamerId ==) mVoterId
+      let selfReport = case banReporter of
+            BySpamer _ -> True
+            _ -> False
       mPollState <- liftIO $ HT.lookup chatStateActivePolls spamerId
 
       unless (adminReported || selfReport) $ do
         mPoll <- case mPollState of
-          Nothing -> createBanPoll ch chatId spamerId mVoterIdOrBotId voter consensus spamer
+          Nothing -> createBanPoll ch chatId spamerId banReporter consensus spamer
             $! messageInfoId orig
           Just poll -> do
             let currentPollSize = HS.size (pollVoters poll)
-            nextPollState <- case mVoterId of
-              Nothing -> pure poll
-              Just voterId -> fst <$> addVoteToPoll ch voterId spamerId poll
+            nextPollState <- case banReporter of
+              ByBot _ -> pure poll
+              BySpamer _ -> pure poll
+              ByUser userId -> fst <$> addVoteToPoll ch (userId) spamerId poll
+              ByAdmin userId -> fst <$> addVoteToPoll ch (VoterId userId) spamerId poll
             let pollSizeChanged = currentPollSize /= HS.size (pollVoters nextPollState)
             pure $! Just (pollSizeChanged, nextPollState)
 
         -- at this point poll *must* be created
-        forM_ mPoll $ \poll -> proceedWithPoll ch chatId spamerId mVoterId (Just orig) poll
+        forM_ mPoll $ \poll -> proceedWithPoll ch chatId spamerId (toVoterId banReporter) (Just orig) poll
 
 -- | This message is definitely a spam! So let's:
 --
@@ -228,14 +232,12 @@ proceedWithPoll
   => ChatState
   -> ChatId
   -> SpamerId
-  -> Maybe VoterId
+  -> VoterId
   -> Maybe MessageInfo
   -> (Bool, PollState)
   -> BotM ()
-proceedWithPoll ch@ChatState{..} chatId spamerId voterId mOrig (pollChanged, poll@PollState{..}) = do
-  voterIsAdmin <- case voterId of
-    Nothing -> pure False
-    Just vid -> liftIO (isJust <$> HT.lookup chatStateAdmins (coerce @_ @UserId vid))
+proceedWithPoll ch@ChatState{..} chatId spamerId vid mOrig (pollChanged, poll@PollState{..}) = do
+  voterIsAdmin <- liftIO (isJust <$> HT.lookup chatStateAdmins (coerce @_ @UserId vid))
   let consensus = usersForConsensus chatStateSettings
       voters = HS.size pollVoters
       enoughToBan = fromIntegral consensus <= voters || voterIsAdmin
@@ -283,7 +285,7 @@ handleVoteBan chatId ch@ChatState{..} voterId _messageId voteBanId = do
         VoteForBan _ _ -> do
           (newPoll, nextChatState) <- addVoteToPoll ch voterId spamerId poll
           let pollChanged = HS.size (pollVoters poll) /= HS.size (pollVoters newPoll)
-          proceedWithPoll nextChatState chatId spamerId (Just voterId) Nothing (pollChanged, newPoll)
+          proceedWithPoll nextChatState chatId spamerId voterId Nothing (pollChanged, newPoll)
 
 closeBanPoll :: WithBotState => ChatState -> ChatId -> SpamerId -> BotM ()
 closeBanPoll st@ChatState{..} chatId spamerId = do
@@ -308,18 +310,20 @@ createBanPoll
   => ChatState
   -> ChatId
   -> SpamerId
-  -> Maybe VoterId
-  -> Voter
+  -> BanRequestedBy
   -> Integer -- votes required for ban decision
   -> UserInfo -- spamer
   -> MessageId
   -> BotM (Maybe (Bool, PollState))
-createBanPoll st chatId spamerId mVoterId voter consensus spamer messageId = do
+createBanPoll st chatId spamerId banReporter consensus spamer messageId = do
   let BotState{..} = ?model
   let keyboard = InlineKeyboardMarkup
         { inlineKeyboardMarkupInlineKeyboard = voteButtons chatId spamerId
         }
-      replyMsg = (toReplyMessage (voteMessage voter (maybe 0 (const 1) mVoterId) consensus))
+      isBot = case banReporter of
+        ByBot _ -> True
+        _       -> False
+      replyMsg = (toReplyMessage (voteMessage isBot 1 consensus))
         { replyMessageReplyToMessageId = Just messageId
         , replyMessageReplyMarkup = Just $ SomeInlineKeyboardMarkup keyboard
         }
@@ -331,7 +335,7 @@ createBanPoll st chatId spamerId mVoterId voter consensus spamer messageId = do
       then pure Nothing
       else do
         let pollId = messageMessageId responseResult
-        (poll, nextChatState) <- startBanPoll st mVoterId spamerId spamer pollId messageId
+        (poll, nextChatState) <- startBanPoll st banReporter spamerId spamer pollId messageId
         writeCache groups chatId nextChatState
         pure $ Just (False, poll)
 
@@ -352,7 +356,7 @@ updateBanPoll st@ChatState{..} chatId spamerId voters consensus poll@PollState{.
   let keyboard = InlineKeyboardMarkup
         { inlineKeyboardMarkupInlineKeyboard = voteButtons chatId spamerId
         }
-      editMsgTxt = voteMessage UserVoter voters consensus
+      editMsgTxt = voteMessage False voters consensus
       editMsg = (toEditMessage editMsgTxt)
         { editMessageReplyMarkup = Just $ SomeInlineKeyboardMarkup keyboard
         }
@@ -360,19 +364,16 @@ updateBanPoll st@ChatState{..} chatId spamerId voters consensus poll@PollState{.
 
   editMessage editId editMsg
 
-data Voter = BotVoter | UserVoter
-  deriving (Eq, Show)
-
-voteMessage :: Voter -> Int -> Integer -> Text
-voteMessage voter voters consensus = Text.concat
+voteMessage :: Bool -> Int -> Integer -> Text
+voteMessage isBot voters consensus = Text.concat
   [ textVoter
   , " decided that this is a spamer. Is it correct? Vote ("
   , s2t voters , "/", s2t consensus, ")"
   ]
   where
-    textVoter = case voter of
-      BotVoter -> "Bot"
-      UserVoter -> "Someone"
+    textVoter = case isBot of
+      True   -> "Bot"
+      False  -> "Someone"
 
 voteButtons :: ChatId -> SpamerId -> [[InlineKeyboardButton]]
 voteButtons chatId spamerId =

--- a/src/Watcher/Bot/Handle/Message.hs
+++ b/src/Watcher/Bot/Handle/Message.hs
@@ -1,7 +1,7 @@
 module Watcher.Bot.Handle.Message where
 
 import Control.Applicative ((<|>))
-import Control.Concurrent.STM (atomically, modifyTVar')
+import Control.Concurrent.STM (atomically, readTVarIO, modifyTVar')
 import Control.Monad (forM, forM_, unless, void)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Coerce (coerce)
@@ -81,6 +81,8 @@ analyseMessage chatId ch0 userId message = do
         banSpamerInChat chatId spamer
         removeAllQuarantineMessages ch chatId (SpamerId userId)
         selfDestructReply chatId ch (banType spamer)
+  botItself <- liftIO $ readTVarIO self
+  let mBotId = userInfoId <$> botItself
   userAlreadyBanned <- hasUserAlreadyBannedElsewhere userId
   if userAlreadyBanned
     -- if user has banned globally but was unbanned locally, bot will allow such a user
@@ -97,7 +99,8 @@ analyseMessage chatId ch0 userId message = do
         if knownSpamMessage
           then do
             liftIO $ log' @(Text, _) ("analyseMessage.known spam", userId)
-            handleBanByRegularUser chatId ch Nothing messageInfo
+            forM_ mBotId \botId ->
+              handleBanByRegularUser chatId ch (ByBot botId) messageInfo
           else userIsInChatQuarantine ch userId >>= \case
             Nothing ->
               liftIO $ log' @(Text, _) ("analyseMessage.NotInQuarantine", userId)
@@ -117,7 +120,8 @@ analyseMessage chatId ch0 userId message = do
                     liftIO $ log' @(Text, _) ("msg spam", userId)
                     sendEvent (chatEvent now chatId EventGroupRecogniseMostLikelySpam)
                     forwardToOwnersMaybe Spam chatId (messageInfoId messageInfo)
-                    handleBanByRegularUser chatId ch Nothing messageInfo
+                    forM_ mBotId \botId ->
+                      handleBanByRegularUser chatId ch (ByBot botId) messageInfo
 
 incrementQuarantineCounter
   :: WithBotState => ChatId -> ChatState -> UserId -> Int -> Message -> BotM ()
@@ -162,6 +166,9 @@ addUserToQuarantineOrBan
 addUserToQuarantineOrBan chatId ch message newcomer = do
   let BotState {..} = ?model
 
+  botItself <- liftIO $ readTVarIO self
+  let mBotId = userInfoId <$> botItself
+
   liftIO $ log' @(Text, _) ("addUserToQuarantineOrBan", newcomer)
   let uid = userId newcomer
       userInfo = userToUserInfo newcomer
@@ -201,12 +208,14 @@ addUserToQuarantineOrBan chatId ch message newcomer = do
           ProbablySpamMessage _ -> do
             sendEvent (chatEvent now chatId EventGroupRecogniseProbablySpam)
             forwardToOwnersMaybe Spam chatId (messageMessageId message)
-            handleBanByRegularUser chatId ch Nothing (messageToMessageInfo message)
+            forM_ mBotId \botId ->
+              handleBanByRegularUser chatId ch (ByBot botId) (messageToMessageInfo message)
             pure True
           MostLikelySpamMessage _ -> do
             sendEvent (chatEvent now chatId EventGroupRecogniseMostLikelySpam)
             forwardToOwnersMaybe Spam chatId (messageMessageId message)
-            handleBanByRegularUser chatId ch Nothing (messageToMessageInfo message)
+            forM_ mBotId \botId ->
+              handleBanByRegularUser chatId ch (ByBot botId) (messageToMessageInfo message)
             pure True
         case userIsSpammer of
           True -> pure Nothing

--- a/src/Watcher/Bot/State/Chat.hs
+++ b/src/Watcher/Bot/State/Chat.hs
@@ -116,22 +116,23 @@ setupChatSettings st userId time newSettings = st
 startBanPoll
   :: MonadIO m
   => ChatState
-  -> Maybe VoterId
+  -> BanRequestedBy
   -> SpamerId
   -> UserInfo -- ^ Spamer
   -> MessageId -- ^ poll message id
   -> MessageId -- ^ spamer message id
   -> m (PollState, ChatState)
 startBanPoll
-  st@ChatState{..} mVoterId spamerId pollSpamer pollMessageId pollSpamMessageId = liftIO do
-  let newPoll = PollState
+  st@ChatState{..} banReporter spamerId pollSpamer pollMessageId pollSpamMessageId = liftIO do
+  let voterId = toVoterId banReporter
+      newPoll = PollState
         { pollMessageId, pollSpamer, pollSpamMessageId
-        , pollVoters = maybe HS.empty HS.singleton mVoterId
+        , pollVoters = HS.singleton voterId
         }
   poll <- HT.lookup chatStateActivePolls spamerId >>= \case
     Nothing -> pure newPoll
     Just oldPoll -> pure $! oldPoll
-      { pollVoters = maybe HS.empty (flip HS.insert (pollVoters oldPoll)) mVoterId }
+      { pollVoters = HS.insert voterId (pollVoters oldPoll) }
   HT.insert chatStateActivePolls spamerId poll
   pure (poll, st)
 

--- a/src/Watcher/Bot/Types/Common.hs
+++ b/src/Watcher/Bot/Types/Common.hs
@@ -1,6 +1,7 @@
 module Watcher.Bot.Types.Common where
 
 import Data.ByteString (ByteString)
+import Data.Coerce (coerce)
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
 import Data.Hashable (Hashable)
@@ -25,6 +26,17 @@ newtype MessageHash = MessageHash ByteString
 
 hexSha256 :: Text -> MessageHash
 hexSha256 = MessageHash . Base16.encode . SHA256.hash . encodeUtf8
+
+data BanRequestedBy
+  = ByBot UserId | ByUser VoterId | BySpamer SpamerId | ByAdmin UserId
+  deriving (Eq, Show)
+
+toVoterId :: BanRequestedBy -> VoterId
+toVoterId = \case
+  ByBot userId -> VoterId userId
+  ByUser voterId -> voterId
+  BySpamer spamerId -> coerce spamerId
+  ByAdmin userId -> VoterId userId
 
 newtype SpamerId = SpamerId UserId
   deriving newtype (Eq, Show, Read, Hashable, FromDhall, ToDhall)


### PR DESCRIPTION
When ban action initiated by bot itself, it's necessary to handle it more thoroughly. With extra data type the context should be more clear.