### PR TITLE
Take groups cache outside of TVar

### DIFF
--- a/src/Watcher/Bot.hs
+++ b/src/Watcher/Bot.hs
@@ -1,7 +1,7 @@
 module Watcher.Bot where
 
 import Control.Concurrent.Async (Concurrently (..), runConcurrently)
-import Control.Concurrent.STM (TVar, atomically, modifyTVar')
+import Control.Concurrent.STM (TVar, atomically, newTVarIO, modifyTVar')
 import Control.Exception (finally)
 import Control.Monad (forM, forM_, join, void, unless)
 import Control.Monad.IO.Class (liftIO)
@@ -103,7 +103,9 @@ gatherBlocklistStats cache =  do
 
 gatherStatistics :: WithBotState => IO ()
 gatherStatistics = every statistics $ do
-  groupsStats <- gatherCacheStats "Groups" groups fromHMap
+  -- FIXME: there should be a better way
+  groupTVar <- newTVarIO groups
+  groupsStats <- gatherCacheStats "Groups" groupTVar fromHMap
   adminsStats <- gatherCacheStats "Admins" admins fromHMap
   usersStats <- gatherCacheStats "Users" users fromHMap
   blocklistStats <- gatherBlocklistStats blocklist
@@ -146,7 +148,7 @@ autoban = do
               ]
         replyStats message
 
-  groupsMap <- fromHMap =<< readCache groups
+  groupsMap <- fromHMap groups
   chatCounter <- newIORef (0 :: Int)
 
   messages <- forM (HM.toList groupsMap) $ \(chatId, ChatState{..}) -> do

--- a/src/Watcher/Bot/Handle/Ban.hs
+++ b/src/Watcher/Bot/Handle/Ban.hs
@@ -56,8 +56,9 @@ handleAdminBan chatId ch@ChatState{..} userId messageId adminBanId = do
     case adminBanId of
       AdminAgainstBan _ _ -> do
         void $ call $ deleteMessage chatId messageId
-        liftIO $ HT.delete chatStateAdminCalls spamerId
-        writeCache groups chatId ch
+        liftIO do
+          HT.delete chatStateAdminCalls spamerId
+          HT.insert groups chatId ch
         pure ()
       AdminForBan _ _ -> do
         void $ call $ deleteMessage chatId messageId
@@ -70,7 +71,7 @@ handleAdminBan chatId ch@ChatState{..} userId messageId adminBanId = do
             liftIO do
               HT.delete chatStateAdminCalls spamerId
               HT.delete chatStateQuarantine (coerce @_ @UserId spamerId)
-            writeCache groups chatId ch
+              HT.insert groups chatId ch
             selfDestructReply chatId ch (ReplyUserAlreadyBanned spamer)
 
 banSpamerInChat :: WithBotState => ChatId -> UserInfo -> BotM ()
@@ -131,8 +132,9 @@ handleBanViaAdminsCall
 handleBanViaAdminsCall chatId ch@ChatState{..} spamer orig = do
   let BotState {..} = ?model
       spamerId = SpamerId $! userInfoId spamer
-  liftIO $ HT.insert chatStateAdminCalls spamerId (spamer, orig)
-  writeCache groups chatId ch
+  liftIO do
+    HT.insert chatStateAdminCalls spamerId (spamer, orig)
+    HT.insert groups chatId ch
 
   (call $ getChatAdministrators (SomeChatId chatId)) >>= \case
     Just Response{..} -> if not responseOk
@@ -290,14 +292,16 @@ handleVoteBan chatId ch@ChatState{..} voterId _messageId voteBanId = do
 closeBanPoll :: WithBotState => ChatState -> ChatId -> SpamerId -> BotM ()
 closeBanPoll st@ChatState{..} chatId spamerId = do
   let BotState {..} = ?model
-  liftIO $ HT.delete chatStateActivePolls spamerId
-  writeCache groups chatId st
+  liftIO do
+    HT.delete chatStateActivePolls spamerId
+    HT.insert groups chatId st
 
 allowUserInGroup :: WithBotState => ChatState -> ChatId -> UserId -> BotM ()
 allowUserInGroup st@ChatState{..} chatId userId = do
   let BotState {..} = ?model
-  liftIO $ HT.insert chatStateAllowlist userId ()
-  writeCache groups chatId st
+  liftIO do
+    HT.insert chatStateAllowlist userId ()
+    HT.insert groups chatId st
 
 removeAllQuarantineMessages :: WithBotState => ChatState -> ChatId -> SpamerId -> BotM ()
 removeAllQuarantineMessages ChatState{..} chatId spamerId = do
@@ -336,7 +340,7 @@ createBanPoll st chatId spamerId banReporter consensus spamer messageId = do
       else do
         let pollId = messageMessageId responseResult
         (poll, nextChatState) <- startBanPoll st banReporter spamerId spamer pollId messageId
-        writeCache groups chatId nextChatState
+        liftIO $ HT.insert groups chatId nextChatState
         pure $ Just (False, poll)
 
 updateBanPoll
@@ -350,8 +354,9 @@ updateBanPoll
   -> BotM ()
 updateBanPoll st@ChatState{..} chatId spamerId voters consensus poll@PollState{..} = do
   let BotState {..} = ?model
-  liftIO $ HT.insert chatStateActivePolls spamerId poll
-  writeCache groups chatId st
+  liftIO do
+    HT.insert chatStateActivePolls spamerId poll
+    HT.insert groups chatId st
 
   let keyboard = InlineKeyboardMarkup
         { inlineKeyboardMarkupInlineKeyboard = voteButtons chatId spamerId

--- a/src/Watcher/Bot/Handle/Debug.hs
+++ b/src/Watcher/Bot/Handle/Debug.hs
@@ -57,7 +57,7 @@ debugSetup Message{..} = do
     let go Nothing = Just
           $! ncs { chatStateAdmins = singleAdmin }
         go (Just v) = Just v
-    alterCache groups chatId go
+    liftIO $ HT.alter groups go chatId
     writeCache admins userId' =<< liftIO (toHSet (HS.singleton group))
   when readyOrNot $ forM_ mUserId $ \userId' -> setSingleRoot userId' (fst group)
   replySingleGroupRoot readyOrNot (Just chatId) (ReplySetup messageMessageId)
@@ -96,7 +96,7 @@ debugSpam msg = do
                      }
                    }
           mid = messageMessageId msg
-      writeCache groups chatId ch
+      liftIO $ HT.insert groups chatId ch
       writeCache admins userId' =<< liftIO (toHSet (HS.singleton group))
 
       handleBanAction chatId ch (VoterId userId') mid $! messageToMessageInfo orig
@@ -121,7 +121,7 @@ handleGetChatMember :: WithBotState => ChatId -> BotM ()
 handleGetChatMember chatId = do
   let BotState{..} = ?model
       Settings {..} = botSettings
-  forM_ ownerGroup $ \OwnerGroupSettings {} -> lookupCache groups chatId >>= \case
+  forM_ ownerGroup $ \OwnerGroupSettings {} -> (liftIO $ HT.lookup groups chatId) >>= \case
     Nothing -> replyText "No data for requested chat"
     Just ChatState{..} -> do
       (liftIO $ HT.toList chatStateQuarantine) >>= \case

--- a/src/Watcher/Bot/Handle/Dump.hs
+++ b/src/Watcher/Bot/Handle/Dump.hs
@@ -1,5 +1,6 @@
 module Watcher.Bot.Handle.Dump where
 
+import Control.Concurrent.STM (newTVarIO)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
@@ -21,7 +22,9 @@ dumpAllCachesOnce = do
 
   liftIO do
     now <- getCurrentTime
-    dumpCache now groupsPath groups transformChatExports
+    -- FIXME: there should be a better way
+    groupTVar <- newTVarIO groups
+    dumpCache now groupsPath groupTVar transformChatExports
     dumpCache now adminsPath admins transformAdminExports
     dumpCache now usersPath users fromHMap
     dumpCache now blocklistPath blocklist blocklistToStorage

--- a/src/Watcher/Bot/Handle/Message.hs
+++ b/src/Watcher/Bot/Handle/Message.hs
@@ -36,11 +36,15 @@ import Watcher.Bot.Utils
 handleAnalyseMessage :: WithBotState => ChatId -> UserId -> Message -> BotM ()
 handleAnalyseMessage chatId userId message = do
   let BotState {..} = ?model
-  mChatState <- lookupCache groups chatId
-  forM_ mChatState $ \ch@ChatState{..} -> case chatStateSetup of
-    SetupNone -> pure ()
-    SetupInProgress {} -> pure ()
-    SetupCompleted {} -> analyseMessage chatId ch userId message
+
+  (liftIO $ HT.lookup groups chatId) >>= \case
+    Nothing -> pure ()
+    Just ch -> case chatStateSetup ch of
+      SetupNone -> pure ()
+      SetupInProgress {} -> pure ()
+      SetupCompleted {} -> do
+        analyseMessage chatId ch userId message
+        liftIO $ HT.insert groups chatId ch
 
 handleTuning :: WithBotState => Update -> BotM ()
 handleTuning Update{..} = do
@@ -70,17 +74,15 @@ handleTuning Update{..} = do
         replyTuning (messageMessageId msg) (messageMessageThreadId msg) decision
 
 analyseMessage :: WithBotState => ChatId -> ChatState -> UserId -> Message -> BotM ()
-analyseMessage chatId ch0 userId message = do
+analyseMessage chatId ch userId message = do
   let BotState {..} = ?model
 
   forM_ (messageNewChatMembers message) $ \newcomers -> do
     liftIO $ log' @(Text, _) ("analyseMessage.newcomers", userId)
     let newcomersIncludingSender = (maybeToList . messageFrom $ message) <> newcomers
-    addUsersToQuarantineOrBan chatId ch0 message newcomersIncludingSender
+    addUsersToQuarantineOrBan chatId ch message newcomersIncludingSender
 
-  mChatState <- lookupCache groups chatId
-  let ch = fromMaybe ch0 mChatState
-      messageInfo = messageToMessageInfo message
+  let messageInfo = messageToMessageInfo message
 
       fullBan banType extraMessages = forM_ (messageFrom message) \spamerUser -> do
         let spamer = userToUserInfo spamerUser
@@ -150,8 +152,9 @@ incrementQuarantineCounter chatId ch@ChatState{..} userId inQuarantine Message{.
               { quarantineMessageHash = Set.insert hash quarantineMessageHash
               , quarantineMessageId = Set.insert messageMessageId quarantineMessageId
               }
-        liftIO $ HT.alter chatStateQuarantine go userId
-        writeCache groups chatId ch
+        liftIO do
+          HT.alter chatStateQuarantine go userId
+          HT.insert groups chatId ch
 
 userIsInChatQuarantine :: MonadIO m => ChatState -> UserId -> m (Maybe Int)
 userIsInChatQuarantine ChatState{..} userId = do
@@ -161,23 +164,24 @@ userIsInChatQuarantine ChatState{..} userId = do
 endQuarantineForUser :: (WithBotState, MonadIO m) => ChatId -> UserId -> m ()
 endQuarantineForUser chatId userId = do
   let BotState {..} = ?model
-  mChatState <- lookupCache groups chatId
+  mChatState <- liftIO $ HT.lookup groups chatId
   forM_ mChatState \ch@ChatState{..} -> do
-    liftIO $ HT.delete chatStateQuarantine userId
-    writeCache groups chatId ch
+    liftIO do
+      HT.delete chatStateQuarantine userId
+      HT.insert groups chatId ch
 
 -- | Returns 'Nothing', if user was not added to quarantine.
 -- Otherwise User with their chat info optionally.
-addUserToQuarantineOrBan
+banUserOrPrepareToQuarantine
   :: WithBotState
   => ChatId -> ChatState -> Message -> User -> BotM (Maybe (Maybe ChatInfo, User))
-addUserToQuarantineOrBan chatId ch message newcomer = do
+banUserOrPrepareToQuarantine chatId ch message newcomer = do
   let BotState {..} = ?model
 
   botItself <- liftIO $ readTVarIO self
   let mBotId = userInfoId <$> botItself
 
-  liftIO $ log' @(Text, _) ("addUserToQuarantineOrBan", newcomer)
+  liftIO $ log' @(Text, _) ("banUserOrPrepareToQuarantine", newcomer)
   let uid = userId newcomer
       userInfo = userToUserInfo newcomer
 
@@ -238,11 +242,10 @@ addUserToQuarantineOrBan chatId ch message newcomer = do
             liftIO $ atomically $! modifyTVar' eventSet $! Set.insert evt
             pure $ Just ((toChatInfo . responseResult) <$> mResponse, newcomer)
 
-addUsersToQuarantineOrBan :: WithBotState => ChatId -> ChatState -> Message -> [User] -> BotM ()
+addUsersToQuarantineOrBan :: WithBotState => ChatId -> ChatState -> Message -> [User] -> BotM ChatState
 addUsersToQuarantineOrBan chatId ch@ChatState{..} message newcomers = do
-  let BotState {..} = ?model
   newcomersWithChats <- forM newcomers $ \newcomer -> do
-    addUserToQuarantineOrBan chatId ch message newcomer
+    banUserOrPrepareToQuarantine chatId ch message newcomer
 
   let toQuarantineEntry (mChat, User{..}) =
         (userId, emptyQuarantineState
@@ -250,14 +253,12 @@ addUsersToQuarantineOrBan chatId ch@ChatState{..} message newcomers = do
           , quarantineMessageId = Set.singleton $ messageMessageId message
           })
       qEntries = toQuarantineEntry <$> catMaybes newcomersWithChats
+
+      go qs Nothing = (Just qs)
+      go qs (Just prevQs) = Just $ prevQs <> qs
+  forM_ qEntries \(userId, qs) -> liftIO $ HT.alter chatStateQuarantine (go qs) userId
   liftIO $ log' @(Text, _) ("addUsersToQuarantineOrBan.newEntries", qEntries)
-
-  newUserMap <- liftIO $ HT.fromList qEntries
-  nextQuarantine <- liftIO $ HT.unionWith (<>) chatStateQuarantine newUserMap
-  let nextState = ch { chatStateQuarantine = nextQuarantine }
-
-  writeCache groups chatId nextState
-
+  pure ch
 
 data UserMessageScore = UserMessageScore
   { userMessageScoreNoUsername :: Int

--- a/src/Watcher/Bot/Handle/Setup.hs
+++ b/src/Watcher/Bot/Handle/Setup.hs
@@ -88,7 +88,7 @@ refreshChatAdmins :: WithBotState => ChatId -> BotM ()
 refreshChatAdmins chatId = do
   let BotState {..} = ?model
   now <- liftIO getCurrentTime
-  mChatState <- lookupCache groups chatId
+  mChatState <- liftIO $ HT.lookup groups chatId
   ncs <- newChatState botSettings
   let st = fromMaybe ncs mChatState
   when True $ do
@@ -106,7 +106,7 @@ refreshChatAdmins chatId = do
               , chatStateAdmins = newChatAdmins
               , chatStateBotIsAdmin = botIsAdmin'
               }
-        liftIO $ writeCache groups chatId newState
+        liftIO $ HT.insert groups chatId newState
 
         mChatResponse <- call $ getChat (SomeChatId chatId)
         let mChatTitle = chatFullInfoTitle =<< (responseResult <$> mChatResponse)
@@ -172,7 +172,7 @@ initGroupSetupMaybe :: WithBotState => UserId -> (ChatId, Maybe Text) -> BotM Bo
 initGroupSetupMaybe userId (chatId, _mChatname) = do
   let BotState {..} = ?model
   now <- liftIO getCurrentTime
-  mChatState <- lookupCache groups chatId
+  mChatState <- liftIO $ HT.lookup groups chatId
 
   case mChatState of
     -- bot does not know anything about the group. that's weird!
@@ -247,15 +247,15 @@ overrideChatSettings
   => ChatId -> ChatState
   -> UserId -> UTCTime -> GroupSettings
   -> BotM ()
-overrideChatSettings chatId chatState userId now chatSettings =
+overrideChatSettings chatId chatState userId now chatSettings = do
   let BotState{..} = ?model
-  in writeCache groups chatId $! setupChatSettings chatState userId now chatSettings
+  liftIO $ HT.insert groups chatId $! setupChatSettings chatState userId now chatSettings
 
 completeGroupSetup :: WithBotState => ChatId -> UserId -> BotM ()
 completeGroupSetup chatId userId = do
   let BotState {..} = ?model
   now <- liftIO getCurrentTime
-  alterCache groups chatId (go now)
+  liftIO $ HT.alter groups (go now) chatId
   where
     go _time Nothing = Nothing
     go time (Just prevState) = Just
@@ -265,7 +265,7 @@ groupSetup :: WithBotState => ChatId -> UserId -> MenuId -> BotM ()
 groupSetup chatId userId menuId = do
   let BotState {..} = ?model
   now <- liftIO getCurrentTime
-  mChatState <- lookupCache groups chatId
+  mChatState <- liftIO $ HT.lookup groups chatId
   ncs <- liftIO $ newChatState botSettings
   let chatState = fromMaybe ncs mChatState
       nextChatSettings = alterSettings (chatStateSettings chatState) menuId

--- a/src/Watcher/Bot/Reply.hs
+++ b/src/Watcher/Bot/Reply.hs
@@ -135,7 +135,7 @@ replyCallAdmins chatId spamerId adminUsernames originalMessage = do
 withCompletedSetup :: WithBotState => ChatId -> (ChatState -> BotM ()) -> BotM ()
 withCompletedSetup chatId action = do
   let BotState {..} = ?model
-  mChatState <- lookupCache groups chatId
+  mChatState <- liftIO $ HT.lookup groups chatId
   -- absence of chat state should be ignored
   forM_ mChatState $ \ch@ChatState{..} -> case chatStateSetup of
     SetupNone -> selfDestructReply chatId ch ReplyNoSetup
@@ -171,7 +171,7 @@ replySingleGroupRoot
   => Bool -> Maybe ChatId -> SetupMessageId -> BotM ()
 replySingleGroupRoot True mChatId messageId = do
   let BotState {..} = ?model
-  mChatState <- maybe (pure Nothing) (lookupCache groups) mChatId
+  mChatState <- maybe (pure Nothing) (liftIO . HT.lookup groups) mChatId
   let setupKeyboard0 = InlineKeyboardMarkup
         { inlineKeyboardMarkupInlineKeyboard = fmap (fmap (uncurry actionButton))
             [ [ ("Users for ban consensus", ConsensusRoot) ]

--- a/src/Watcher/Bot/State.hs
+++ b/src/Watcher/Bot/State.hs
@@ -85,7 +85,7 @@ data BotState = BotState
   , logEnv :: LogEnv
   , casClient :: Manager
   -- caches
-  , groups :: TVar Groups
+  , groups :: Groups
   , admins :: TVar Admins
   , users :: TVar Users
   , blocklist :: TVar Blocklist
@@ -100,7 +100,7 @@ newBotState settings@Settings{..} = do
   admins <- newTVarIO =<< HT.initialize 0
   clientEnv <- createTelegramClientEnv
     (Token botToken) (fromIntegral botConnectionCount) (fromIntegral botResponseTimeout)
-  groups <- newTVarIO =<< HT.initialize 0
+  groups <- HT.initialize 0
   users <- newTVarIO =<< HT.initialize 0
   blocklist <- newTVarIO =<< storageToBlocklist mempty
   spamMessages <- newTVarIO =<< HT.initialize 0
@@ -125,7 +125,7 @@ importBotState settings@Settings {..} = do
   casClient <- newCasClient
 
   admins <- newTVarIO =<< transformAdminImports =<< importCache adminsPath
-  groups <- newTVarIO =<< transformChatImports =<< importCache groupsPath
+  groups <- transformChatImports =<< importCache groupsPath
   users <- newTVarIO =<< toHMap =<< importCache usersPath
   blocklist <- newTVarIO =<< storageToBlocklist =<< importCache blocklistPath
   spamMessages <- newTVarIO =<< toHMap =<< importCache spamMessagesPath


### PR DESCRIPTION
- Also, instead of creating a new quarantine table, re-use original one by replacing `unionWith` with `alter`.
- And perform extra write of ChatState, once message is analysed.